### PR TITLE
zlib version update

### DIFF
--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME = 			zlib
-PORTVERSION = 		1.2.8
+PORTVERSION = 		1.2.9
 
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib

--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME = 			zlib
-PORTVERSION = 		1.2.9
+PORTVERSION = 		1.2.10
 
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib

--- a/zlib/distinfo
+++ b/zlib/distinfo
@@ -1,2 +1,2 @@
-SHA256 (zlib-1.2.9.tar.gz) = 73ab302ef31ed1e74895d2af56f52f5853f26b0370f3ef21954347acec5eaa21
-SIZE (zlib-1.2.9.tar.gz) = 607350
+SHA256 (zlib-1.2.10.tar.gz) = 8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017
+SIZE (zlib-1.2.10.tar.gz) = 607647

--- a/zlib/distinfo
+++ b/zlib/distinfo
@@ -1,2 +1,2 @@
-SHA256 (zlib-1.2.8.tar.gz) = 36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
-SIZE (zlib-1.2.8.tar.gz) = 571091
+SHA256 (zlib-1.2.9.tar.gz) = 73ab302ef31ed1e74895d2af56f52f5853f26b0370f3ef21954347acec5eaa21
+SIZE (zlib-1.2.9.tar.gz) = 607350


### PR DESCRIPTION
Zlib just had two updates (one major and a quick bug fix update), you only have to pull the second patch.  The old version isn't available to download, so you need to update or change the url to somewhere it's archived.