### PR TITLE
libbz2 MAKEFILE: added bzip2-1.0.6 mirror

### DIFF
--- a/libbz2/Makefile
+++ b/libbz2/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Block-sorting compression library
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-DOWNLOAD_SITE = 	http://bzip.org/${PORTVERSION}
+# ~CA~ 8.16.18 - bzip.org is down, now points to an unofficial mirror on Github; verified distinfo matches.
+DOWNLOAD_SITE = 	https://github.com/nemequ/bzip2/releases/download/v1.0.6/${PORTVERSION}
 DOWNLOAD_FILES = 	bzip2-${PORTVERSION}.tar.gz
 
 TARGET =			libbz2.a


### PR DESCRIPTION
bzip.org is belly-up, resulting in failed compilations of kos-ports (at least, for utils/build-all.sh). I've added an unofficial mirror of bzip2 releases -  verified that the grabbed distro matches the _SHA256_ and _SIZE_ strings from _distinfo_. Verified installation of kos-ports can resume as normal with the Github release mirror.
