### PR TITLE
libjpeg: update jpegsrc to v9d

### DIFF
--- a/libjpeg/Makefile
+++ b/libjpeg/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =        libjpeg
-PORTVERSION =     9.3
+PORTVERSION =     9.4
 
 MAINTAINER =      Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =         IJG license (see README in the source distribution!)
@@ -11,12 +11,12 @@ DEPENDENCIES =
 
 # What files we need to download, and where from.
 DOWNLOAD_SITE =   http://ijg.org/files
-DOWNLOAD_FILES =  jpegsrc.v9c.tar.gz
+DOWNLOAD_FILES =  jpegsrc.v9d.tar.gz
 
 TARGET =          libjpeg.a
 INSTALLED_HDRS =  jconfig.h jmorecfg.h jpeg.h jpeglib.h jpegint.h jerror.h
 HDR_INSTDIR =     jpeg
-DISTFILE_DIR =    jpeg-9c
+DISTFILE_DIR =    jpeg-9d
 
 # KOS Distributed extras (to be copied into the build tree)
 KOS_DISTFILES =   KOSMakefile.mk kos_img.c kos_texture.c jpeg.h

--- a/libjpeg/distinfo
+++ b/libjpeg/distinfo
@@ -1,2 +1,2 @@
-SHA256 (jpegsrc.v9c.tar.gz) = 650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122
-SIZE (jpegsrc.v9c.tar.gz) = 1028134
+SHA256 (jpegsrc.v9d.tar.gz) = 6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee
+SIZE (jpegsrc.v9d.tar.gz) = 1070084


### PR DESCRIPTION
I just rebuilt my environment and noticed that the jpegsrc v9c source as hosted doesn't build (SHA hash difference) and so I updated it to the v9d version which was updated on January 12th, 2021 