### PR TITLE
Fixed MacOS build by reverting sed command

### DIFF
--- a/lua/files/KOSMakefile.mk
+++ b/lua/files/KOSMakefile.mk
@@ -11,7 +11,7 @@ OBJS = src/lapi.o src/lauxlib.o src/lbaselib.o src/lcode.o \
 defaultall: fixconf $(OBJS) subdirs linklib
 
 fixconf:
-	sed -e 's/#define LUA_32BITS	0/#define LUA_32BITS	1/' -ibak src/luaconf.h
+	sed -e 's/#define LUA_32BITS[[:space:]+]0/#define LUA_32BITS 1/' -ibak src/luaconf.h
 
 KOS_CFLAGS += -Isrc
 

--- a/lua/files/KOSMakefile.mk
+++ b/lua/files/KOSMakefile.mk
@@ -11,8 +11,7 @@ OBJS = src/lapi.o src/lauxlib.o src/lbaselib.o src/lcode.o \
 defaultall: fixconf $(OBJS) subdirs linklib
 
 fixconf:
-	awk '{gsub(/#define LUA_32BITS	0/, "#define LUA_32BITS	1");print}' src/luaconf.h > luaconf_temp.h
-	mv ./luaconf_temp.h src/luaconf.h
+	sed -e 's/#define LUA_32BITS	0/#define LUA_32BITS	1/' -ibak src/luaconf.h
 
 KOS_CFLAGS += -Isrc
 

--- a/lua/files/KOSMakefile.mk
+++ b/lua/files/KOSMakefile.mk
@@ -11,7 +11,8 @@ OBJS = src/lapi.o src/lauxlib.o src/lbaselib.o src/lcode.o \
 defaultall: fixconf $(OBJS) subdirs linklib
 
 fixconf:
-	sed -i 's/#define LUA_32BITS	0/#define LUA_32BITS	1/' src/luaconf.h
+	awk '{gsub(/#define LUA_32BITS	0/, "#define LUA_32BITS	1");print}' src/luaconf.h > luaconf_temp.h
+	mv ./luaconf_temp.h src/luaconf.h
 
 KOS_CFLAGS += -Isrc
 


### PR DESCRIPTION
MacOS sed is fundamentally incompatible with GNU's, so the 32bit-mode macro replacement was causing build failures on MacOS. Changed to awk, tested on both platforms.