### PR TITLE
FreeType: Disable building with harfbuzz

### DIFF
--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -25,7 +25,7 @@ DISTFILE_DIR =      freetype-${PORTVERSION}
 
 
 # Autotools setup work.
-CONFIGURE_ARGS =    --disable-mmap --with-brotli=no
+CONFIGURE_ARGS =    --disable-mmap --with-brotli=no --with-harfbuzz=no
 CONFIGURE_DEFS =    ZLIB_CFLAGS=-I${KOS_PORTS}/include/zlib ZLIB_LIBS=-lz \
                     BZIP2_CFLAGS=-I${KOS_PORTS}/include/bzlib BZIP2_LIBS=-lbz2 \
                     LIBPNG_CFLAGS="-I${KOS_PORTS}/include/png -std=gnu11" LIBPNG_LIBS=-lpng


### PR DESCRIPTION
This fixes issue #16 where pkg-config is called and the build attempts to use the host's version of harfbuzz which attempts to link with pthread. Disabling it stops this search from occuring and allows the build to complete successfully.