### PR TITLE
Add ALdc as libAL

### DIFF
--- a/libAL/Makefile
+++ b/libAL/Makefile
@@ -1,0 +1,22 @@
+# Port Metadata
+PORTNAME = 			libAL
+PORTVERSION = 		1.0.0
+
+MAINTAINER =        Luke Benstead <kazade@gmail.com>
+LICENSE =           MIT License
+SHORT_DESC =        OpenAL implementation for KOS
+
+# No dependencies beyond the base system.
+DEPENDENCIES =
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://gitlab.com/simulant/aldc.git
+
+TARGET =		libAL.a
+INSTALLED_HDRS =	include/AL/al.h include/AL/alc.h include/AL/alut.h
+HDR_COMDIR =		AL
+
+# KOS Distributed extras (to be copied into the build tree)
+KOS_DISTFILES =		KOSMakefile.mk
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libAL/files/KOSMakefile.mk
+++ b/libAL/files/KOSMakefile.mk
@@ -1,0 +1,7 @@
+TARGET = libAL.a
+OBJS =  src/alut.o src/buffer.o src/context.o src/core.o src/listener.o
+OBJS += src/math.o src/platform.o src/source.o
+
+KOS_CFLAGS += -Iinclude -ffast-math -O3
+
+include ${KOS_PORTS}/scripts/lib.mk

--- a/libAL/pkg-descr
+++ b/libAL/pkg-descr
@@ -1,0 +1,3 @@
+ALdc is an OpenAL 1.1 implementation for KOS.  
+
+It implements 3D positional audio for sound effects and offloads all of the panning and mixing to the AICA.


### PR DESCRIPTION
I'm not *totally* sure I've done this correctly - but this PR should add ALdc as libAL in kos-ports.