### PR TITLE
Update zlib to 1.3

### DIFF
--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =        zlib
-PORTVERSION =     1.2.13
+PORTVERSION =     1.3
 
 MAINTAINER =      Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =         zlib License - http://opensource.org/licenses/Zlib

--- a/zlib/distinfo
+++ b/zlib/distinfo
@@ -1,2 +1,2 @@
-SHA256 (zlib-1.2.13.tar.gz) = b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
-SIZE (zlib-1.2.13.tar.gz) = 1497445
+SHA256 (zlib-1.3.tar.gz) = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
+SIZE (zlib-1.3.tar.gz) = 1495873


### PR DESCRIPTION
zlib just had a new release and now the URL for the current 1.2.13 no longer successfully downloads. Updating zlib to 1.3 to fix it.