### PR TITLE
Replace KallistiGL with GLdc as libGL

### DIFF
--- a/libGL/Makefile
+++ b/libGL/Makefile
@@ -1,19 +1,19 @@
 # Port Metadata
 PORTNAME = 			libGL
-PORTVERSION = 		2.0.0
+PORTVERSION = 		1.0.0
 
-MAINTAINER =        Josh Pearson <ph3nom@users.sourceforge.net>
-LICENSE =           KOS License
-SHORT_DESC =        OpenGL (tm) like graphics library for KOS
+MAINTAINER =        Luke Benstead <kazade@gmail.com>
+LICENSE =           2-clause BSD (see LICENSE in the source distribution)
+SHORT_DESC =        GLdc, an OpenGL (tm) like graphics library for KOS
 
 # No dependencies beyond the base system.
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libgl
+GIT_REPOSITORY =    https://gitlab.com/simulant/GLdc.git
 
 TARGET =			libGL.a
-INSTALLED_HDRS =	include/gl.h include/glext.h include/glu.h include/glut.h
+INSTALLED_HDRS =	include/GL/gl.h include/GL/glext.h include/GL/glkos.h include/GL/glu.h
 HDR_COMDIR =		GL
 
 # KOS Distributed extras (to be copied into the build tree)

--- a/libGL/files/KOSMakefile.mk
+++ b/libGL/files/KOSMakefile.mk
@@ -1,8 +1,18 @@
 TARGET = libGL.a
-OBJS =  gl-rgb.o gl-fog.o gl-sh4-light.o gl-light.o gl-clip.o gl-clip-arrays.o
-OBJS += gl-arrays.o gl-pvr.o gl-matrix.o gl-api.o gl-texture.o glu-texture.o
-OBJS += gl-framebuffer.o gl-cap.o gl-error.o
+OBJS =  containers/aligned_vector.o containers/named_array.o containers/stack.o
+OBJS += GL/draw.o GL/error.o GL/flush.o GL/fog.o GL/framebuffer.o GL/glu.o
+OBJS += GL/immediate.o GL/lighting.o GL/matrix.o GL/state.o GL/texture.o GL/util.o
+OBJS += GL/alloc/alloc.o version.o GL/platforms/sh4.o
 
-KOS_CFLAGS += -Iinclude -ffast-math -O3 -DBUILD_LIBGL
+KOS_CFLAGS += -DBACKEND_KOSPVR
+
+GLDC_VERSION=$(shell git describe --abbrev=4 --dirty --always --tags)
+
+defaultall: version $(OBJS)
+
+# Generate version
+version:
+	@cp GL/version.c.in version.c
+	@sed -i "s/@GLDC_VERSION@/${GLDC_VERSION}/g" version.c
 
 include ${KOS_PORTS}/scripts/lib.mk

--- a/libGL/pkg-descr
+++ b/libGL/pkg-descr
@@ -1,6 +1,6 @@
-KallistiGL is an OpenGL (tm) like library written for KOS. The current version
-of this library implements much of version 1.1 of the OpenGL specification and
-some additional functionality beyond that.
+GLdc is a partial implementation of OpenGL 1.2 for the Sega Dreamcast for use
+with the KallistiOS SDK. The aim is to implement as much of OpenGL 1.2 as
+possible, and to add additional features via extensions.
 
 Note that this is not a full implementation of any version of OpenGL and is not
 endorsed by or associated with the Khronos Group or SGI.

--- a/libKGL/Makefile
+++ b/libKGL/Makefile
@@ -1,0 +1,22 @@
+# Port Metadata
+PORTNAME = 			libKGL
+PORTVERSION = 		2.0.0
+
+MAINTAINER =        Nobody
+LICENSE =           KOS License
+SHORT_DESC =        KallistiGL, deprecated OpenGL (tm) like graphics library for KOS
+
+# No dependencies beyond the base system.
+DEPENDENCIES =
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libgl
+
+TARGET =			libKGL.a
+INSTALLED_HDRS =	include/gl.h include/glext.h include/glu.h include/glut.h
+HDR_COMDIR =		KGL
+
+# KOS Distributed extras (to be copied into the build tree)
+KOS_DISTFILES =		KOSMakefile.mk
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libKGL/files/KOSMakefile.mk
+++ b/libKGL/files/KOSMakefile.mk
@@ -1,0 +1,8 @@
+TARGET = libKGL.a
+OBJS =  gl-rgb.o gl-fog.o gl-sh4-light.o gl-light.o gl-clip.o gl-clip-arrays.o
+OBJS += gl-arrays.o gl-pvr.o gl-matrix.o gl-api.o gl-texture.o glu-texture.o
+OBJS += gl-framebuffer.o gl-cap.o gl-error.o
+
+KOS_CFLAGS += -Iinclude -ffast-math -O3 -DBUILD_LIBGL
+
+include ${KOS_PORTS}/scripts/lib.mk

--- a/libKGL/pkg-descr
+++ b/libKGL/pkg-descr
@@ -1,0 +1,6 @@
+KallistiGL is an OpenGL (tm) like library written for KOS. The current version
+of this library implements much of version 1.1 of the OpenGL specification and
+some additional functionality beyond that.
+
+Note that this is not a full implementation of any version of OpenGL and is not
+endorsed by or associated with the Khronos Group or SGI.


### PR DESCRIPTION
This branch currently renames libGL (KallistiGL) to `libKGL` and adds @kazade's GLdc as the new `libGL`. 

I will create a KallistiOS branch which has all the `kgl` directory examples modified to link against `libKGL`, and meanwhile, we can port and create examples for GLdc within that branch. See the KallistiOS branch here: https://github.com/KallistiOS/KallistiOS/pull/353

When we are satisfied that GLdc is ready, we can remove all the KGL stuff from both branches and then merge them both.