### PR TITLE
`libjimtcl`: adding `pkg-descr` file.

### DIFF
--- a/libjimtcl/pkg-descr
+++ b/libjimtcl/pkg-descr
@@ -1,0 +1,6 @@
+Jim Tcl is an open-source small footprint implementation of the Tcl programming
+language. Tcl, or Tool Command Language, originally by John Ousterhout, is an
+open-source multi-purpose C library which includes a powerful dynamic scripting
+language.
+
+URL: http://jim.tcl.tk/


### PR DESCRIPTION
Adding a `pkg-descr` file for [Jim Tcl](https://jim.tcl.tk/), using a summary extracted from the [official Wiki of Tcl](https://wiki.tcl-lang.org/page/What+is+Tcl).

Btw this file is required for [DreamSDK Manager](https://github.com/dreamsdk/manager).