### PR TITLE
Addition of `mruby` KallistiOS Port

### DIFF
--- a/mruby/Makefile
+++ b/mruby/Makefile
@@ -1,0 +1,23 @@
+# Port Metadata
+PORTNAME =          mruby
+PORTVERSION =       3.2.0
+
+MAINTAINER =        X
+LICENSE =           MIT
+SHORT_DESC =        Lightweight Ruby
+
+# No dependencies beyond the base system.
+DEPENDENCIES =
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/mruby/mruby.git
+GIT_BRANCH =		master
+
+TARGET =            libmruby.a
+HDR_DIRECTORY =     build/$(KOS_ARCH)/include
+HDR_INSTDIR =       mruby
+
+# KOS Distributed extras (to be copied into the build tree)
+KOS_DISTFILES =     KOSMakefile.mk
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/mruby/Makefile
+++ b/mruby/Makefile
@@ -2,7 +2,7 @@
 PORTNAME =          mruby
 PORTVERSION =       3.2.0
 
-MAINTAINER =        X
+MAINTAINER =        SiZiOUS <sizious@gmail.com>
 LICENSE =           MIT
 SHORT_DESC =        Lightweight Ruby
 
@@ -11,7 +11,7 @@ DEPENDENCIES =
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/mruby/mruby.git
-GIT_BRANCH =		master
+GIT_BRANCH =        master
 
 TARGET =            libmruby.a
 HDR_DIRECTORY =     build/$(KOS_ARCH)/include

--- a/mruby/files/KOSMakefile.mk
+++ b/mruby/files/KOSMakefile.mk
@@ -1,0 +1,35 @@
+# Windows specific
+ifeq ($(OS),Windows_NT)
+	EXECUTABLEEXTENSION = .exe
+endif
+
+TARGET = libmruby.a
+
+MRUBY_COMPILER = mrbc$(EXECUTABLEEXTENSION)
+MRUBY_INSTALL_DIR = $(KOS_CC_BASE)/../bin
+
+defaultall: | generatemruby copylib installmrbc
+
+# Generate mruby
+#generatemp: export MICROPYTHON_TOP = $(CURDIR)
+generatemruby:
+#	$(MAKE) MRUBY_CONFIG=dreamcast_shelf	
+	@/C/Program\ Files/7-Zip/7z.exe x ../../build.7z -r -o.
+
+copylib:
+	@cp $(CURDIR)/build/$(KOS_ARCH)/lib/$(TARGET) $(CURDIR)
+
+# Install mruby compiler executable (mrbc)
+installmrbc:
+	@cp $(CURDIR)/build/host/bin/$(MRUBY_COMPILER) $(MRUBY_INSTALL_DIR)
+	@strip $(MRUBY_INSTALL_DIR)/$(MRUBY_COMPILER)
+
+# Alter header files and replace #include "{variable}" with #include <micropython/{variable}>
+# This will fixes some other headers as well.
+fixincludes:
+	@echo "Updating includes before installation..."
+	@for _file in $(MP_PORT_DIR)/*.h $(MP_PY_DIR)/*.h $(MP_RT_DIR)/*.h; do \
+		sed -ri -e 's/#include "([^[:space:]]+)"/#include <micropython\/\1>/g' $$_file $(SED_FLAGS); \
+	done
+	@sed -i -e 's/<port\/mpconfigport_common.h>/<micropython\/port\/mpconfigport_common.h>/' mpconfigport.h $(SED_FLAGS)
+	@sed -i -e 's/<mpconfigport.h>/<micropython\/mpconfigport.h>/' $(MP_PY_DIR)/mpconfig.h $(SED_FLAGS)

--- a/mruby/files/KOSMakefile.mk
+++ b/mruby/files/KOSMakefile.mk
@@ -1,35 +1,58 @@
-# Windows specific
-ifeq ($(OS),Windows_NT)
-	EXECUTABLEEXTENSION = .exe
-endif
-
 TARGET = libmruby.a
 
-MRUBY_COMPILER = mrbc$(EXECUTABLEEXTENSION)
+# Definition of build directories
+MRUBY_BUILD_DIR = $(CURDIR)/build
+MRUBY_BUILD_KOS_ARCH_DIR = $(MRUBY_BUILD_DIR)/$(KOS_ARCH)
+
+# Definition of headers directory (as we will need to alter the relations)
+MRUBY_INCLUDE_DIR = $(MRUBY_BUILD_KOS_ARCH_DIR)/include
+MRUBY_INCLUDE_MRUBY_DIR = $(MRUBY_INCLUDE_DIR)/mruby
+MRUBY_INCLUDE_PRESYM_DIR = $(MRUBY_INCLUDE_MRUBY_DIR)/presym
+
+# Handling mruby compiler executable (mrbc)
+# This compiler is necessary to transpile Ruby sources into a C source file
+MRUBY_COMPILER = mrbc
 MRUBY_INSTALL_DIR = $(KOS_CC_BASE)/../bin
 
-defaultall: | generatemruby copylib installmrbc
+# Windows specific
+ifeq ($(OS),Windows_NT)
+	# On Windows, all executables got a file extension
+	EXECUTABLEEXTENSION = .exe
+	
+	# "sed" can display some useless warning related to "permission denied".
+	# We will just hide this, as this is not relevant.
+	SED_FLAGS = >/dev/null 2>&1	
+endif
+
+# mruby compiler executable (mrbc) (with extension if necessary) 
+MRUBY_COMPILER_BIN = $(MRUBY_COMPILER)$(EXECUTABLEEXTENSION)
+
+defaultall: | generatemruby fixincludes copylib installmrbc
 
 # Generate mruby
-#generatemp: export MICROPYTHON_TOP = $(CURDIR)
 generatemruby:
-#	$(MAKE) MRUBY_CONFIG=dreamcast_shelf	
-	@/C/Program\ Files/7-Zip/7z.exe x ../../build.7z -r -o.
+	@echo "Generating mruby..."
+	$(MAKE) MRUBY_CONFIG=dreamcast_shelf
 
+# Copy final library file into the root directory
 copylib:
-	@cp $(CURDIR)/build/$(KOS_ARCH)/lib/$(TARGET) $(CURDIR)
+	@cp $(MRUBY_BUILD_KOS_ARCH_DIR)/lib/$(TARGET) $(CURDIR)
 
 # Install mruby compiler executable (mrbc)
 installmrbc:
-	@cp $(CURDIR)/build/host/bin/$(MRUBY_COMPILER) $(MRUBY_INSTALL_DIR)
-	@strip $(MRUBY_INSTALL_DIR)/$(MRUBY_COMPILER)
+	@echo "Installing $(MRUBY_COMPILER) to $(MRUBY_INSTALL_DIR)..."
+	@cp $(MRUBY_BUILD_DIR)/host/bin/$(MRUBY_COMPILER_BIN) $(MRUBY_INSTALL_DIR)
+	@strip $(MRUBY_INSTALL_DIR)/$(MRUBY_COMPILER_BIN)
 
-# Alter header files and replace #include "{variable}" with #include <micropython/{variable}>
-# This will fixes some other headers as well.
+# Alter header files and alter #include directives
+#	#include "{variable}" => #include <mruby/{variable}>
+#	#include "<mruby/{variable}>" => #include <mruby/mruby/{variable}>
+#	#include "mrbconf.h" => #include <mruby/mrbconf.h> (in "mruby.h")
 fixincludes:
 	@echo "Updating includes before installation..."
-	@for _file in $(MP_PORT_DIR)/*.h $(MP_PY_DIR)/*.h $(MP_RT_DIR)/*.h; do \
-		sed -ri -e 's/#include "([^[:space:]]+)"/#include <micropython\/\1>/g' $$_file $(SED_FLAGS); \
+	@for _file in $(MRUBY_INCLUDE_DIR)/*.h $(MRUBY_INCLUDE_MRUBY_DIR)/*.h $(MRUBY_INCLUDE_PRESYM_DIR)/*.h; do \
+		sed -ri -e 's/#include "([^[:space:]]+)"/#include <mruby\/\1>/g;s/#include <(mruby[^[:space:]]+)>/#include <mruby\/\1>/g' $$_file $(SED_FLAGS); \
 	done
-	@sed -i -e 's/<port\/mpconfigport_common.h>/<micropython\/port\/mpconfigport_common.h>/' mpconfigport.h $(SED_FLAGS)
-	@sed -i -e 's/<mpconfigport.h>/<micropython\/mpconfigport.h>/' $(MP_PY_DIR)/mpconfig.h $(SED_FLAGS)
+	@for _file in $(MRUBY_INCLUDE_DIR)/*.h; do \
+		sed -i -e 's/#include <mruby\/mruby\/mrbconf.h>/#include <mruby\/mrbconf.h>/g' $$_file $(SED_FLAGS); \
+	done

--- a/mruby/pkg-descr
+++ b/mruby/pkg-descr
@@ -1,0 +1,4 @@
+mruby is the lightweight implementation of the Ruby language complying with part
+of the ISO standard. mruby can be linked and embedded within your application. 
+
+URL: https://mruby.org/


### PR DESCRIPTION
Adding **mruby** to KallistiOS Port, based on the excellent work of Yuji Yokoo (@yujiyokoo).
See [Dreamcast Wiki](https://dreamcast.wiki/Using_Ruby_for_Sega_Dreamcast_development) for more details.

[mruby](https://mruby.org/) is the lightweight implementation of the Ruby language complying with part of the ISO standard. mruby can be linked and embedded within your application.

2 examples provided by Yuji Yokoo (@yujiyokoo) will be added to KallistiOS as well.