### PR TITLE
Fix libjpeg

### DIFF
--- a/libjpeg/files/kos_img.c
+++ b/libjpeg/files/kos_img.c
@@ -72,7 +72,9 @@ int jpeg_to_img(const char *filename, int scale, kos_img_t * rv) {
     
 	/* Step 4: set parameters for decompression */
 	assert( scale == 1 || scale == 2 || scale == 4 || scale == 8 );
-	cinfo.scale_num = scale;
+
+	printf("SN: %d, SD: %d\n", cinfo.scale_num, cinfo.scale_denom);
+	cinfo.scale_num = 1;
 	cinfo.scale_denom = scale; /* must be 1, 2, 4, or 8 */
 
 	/* Step 5: Start decompressor */

--- a/libjpeg/files/kos_img.c
+++ b/libjpeg/files/kos_img.c
@@ -72,6 +72,7 @@ int jpeg_to_img(const char *filename, int scale, kos_img_t * rv) {
     
 	/* Step 4: set parameters for decompression */
 	assert( scale == 1 || scale == 2 || scale == 4 || scale == 8 );
+	cinfo.scale_num = scale;
 	cinfo.scale_denom = scale; /* must be 1, 2, 4, or 8 */
 
 	/* Step 5: Start decompressor */

--- a/libjpeg/files/kos_img.c
+++ b/libjpeg/files/kos_img.c
@@ -72,8 +72,6 @@ int jpeg_to_img(const char *filename, int scale, kos_img_t * rv) {
     
 	/* Step 4: set parameters for decompression */
 	assert( scale == 1 || scale == 2 || scale == 4 || scale == 8 );
-
-	printf("SN: %d, SD: %d\n", cinfo.scale_num, cinfo.scale_denom);
 	cinfo.scale_num = 1;
 	cinfo.scale_denom = scale; /* must be 1, 2, 4, or 8 */
 

--- a/libjpeg/files/kos_texture.c
+++ b/libjpeg/files/kos_texture.c
@@ -59,7 +59,7 @@ int jpeg_to_texture(const char * filename, pvr_ptr_t tex, int n, int scale)
      */
     
     /* Step 4: set parameters for decompression */
-    cinfo.scale_num = scale;
+    cinfo.scale_num = 1;
     cinfo.scale_denom = scale; /* must be 1, 2, 4, or 8 */
 
     /* Step 5: Start decompressor */

--- a/libjpeg/files/kos_texture.c
+++ b/libjpeg/files/kos_texture.c
@@ -59,7 +59,7 @@ int jpeg_to_texture(const char * filename, pvr_ptr_t tex, int n, int scale)
      */
     
     /* Step 4: set parameters for decompression */
-    
+    cinfo.scale_num = scale;
     cinfo.scale_denom = scale; /* must be 1, 2, 4, or 8 */
 
     /* Step 5: Start decompressor */


### PR DESCRIPTION
Thanks to SWATs example here: https://github.com/DC-SWAT/DreamShell/blob/f4167ebed5e267f298dde4f8d1dc66e560541cca/lib/SDL_image/IMG_jpg.c#L465

Looks like there was a new scale property that we had to set.  Otherwise it would crash in libjpeg.