### PR TITLE
Add Github mirror URLs to kos-hosted ports

### DIFF
--- a/libKGL/Makefile
+++ b/libKGL/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        KallistiGL, deprecated OpenGL (tm) like graphics library for
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libgl \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libgl \
                     https://github.com/KallistiOS/libkgl.git
 
 TARGET =            libKGL.a

--- a/libKGL/Makefile
+++ b/libKGL/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        KallistiGL, deprecated OpenGL (tm) like graphics library for
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libgl
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libgl \
+                    https://github.com/KallistiOS/libkgl.git
 
 TARGET =            libKGL.a
 INSTALLED_HDRS =    include/gl.h include/glext.h include/glu.h include/glut.h

--- a/libconio/Makefile
+++ b/libconio/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Console-like I/O library
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libconio
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libconio \
+                    https://github.com/KallistiOS/libconio.git
 
 TARGET =            libconio.a
 INSTALLED_HDRS =    include/conio.h include/draw.h include/input.h

--- a/libconio/Makefile
+++ b/libconio/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Console-like I/O library
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libconio \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libconio \
                     https://github.com/KallistiOS/libconio.git
 
 TARGET =            libconio.a

--- a/libdcplib/Makefile
+++ b/libdcplib/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        A portable game programming library
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libdcplib \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libdcplib \
                     https://github.com/KallistiOS/libdcplib.git
 
 TARGET =            libdcplib.a

--- a/libdcplib/Makefile
+++ b/libdcplib/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        A portable game programming library
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libdcplib
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libdcplib \
+                    https://github.com/KallistiOS/libdcplib.git
 
 TARGET =            libdcplib.a
 INSTALLED_HDRS =    include/fnt.h include/sg.h include/ul.h

--- a/libimageload/Makefile
+++ b/libimageload/Makefile
@@ -9,7 +9,8 @@ SHORT_DESC =        Library for decoding BMP, JPEG, and PCX images
 DEPENDENCIES =      libjpeg
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libimageload
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libimageload \
+                    https://github.com/KallistiOS/libimageload.git
 
 TARGET =            libimageload.a
 INSTALLED_HDRS =    include/imageload.h include/jitterdefs.h

--- a/libimageload/Makefile
+++ b/libimageload/Makefile
@@ -9,7 +9,7 @@ SHORT_DESC =        Library for decoding BMP, JPEG, and PCX images
 DEPENDENCIES =      libjpeg
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libimageload \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libimageload \
                     https://github.com/KallistiOS/libimageload.git
 
 TARGET =            libimageload.a

--- a/libkmg/Makefile
+++ b/libkmg/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Library for decoding KMG images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkmg
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkmg \
+                    https://github.com/KallistiOS/libkmg.git
 
 TARGET =            libkmg.a
 INSTALLED_HDRS =    include/kmg.h

--- a/libkmg/Makefile
+++ b/libkmg/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Library for decoding KMG images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkmg \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libkmg \
                     https://github.com/KallistiOS/libkmg.git
 
 TARGET =            libkmg.a

--- a/libkosh/Makefile
+++ b/libkosh/Makefile
@@ -9,7 +9,7 @@ SHORT_DESC =        The KallistiOS shell (library)
 DEPENDENCIES =      libconio
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkosh \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libkosh \
                     https://github.com/KallistiOS/libkosh.git
 
 TARGET =            libkosh.a

--- a/libkosh/Makefile
+++ b/libkosh/Makefile
@@ -9,7 +9,8 @@ SHORT_DESC =        The KallistiOS shell (library)
 DEPENDENCIES =      libconio
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkosh
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libkosh \
+                    https://github.com/KallistiOS/libkosh.git
 
 TARGET =            libkosh.a
 INSTALLED_HDRS =    include/kosh.h

--- a/libmodplug/Makefile
+++ b/libmodplug/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        A library for MOD-like tracker music formats
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmodplug \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libmodplug \
                     https://github.com/KallistiOS/libmodplug.git
 
 TARGET =            libmodplug.a

--- a/libmodplug/Makefile
+++ b/libmodplug/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        A library for MOD-like tracker music formats
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmodplug
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmodplug \
+                    https://github.com/KallistiOS/libmodplug.git
 
 TARGET =            libmodplug.a
 INSTALLED_HDRS =    include/modplug.h include/sndfile.h include/stdafx.h

--- a/libmp3/Makefile
+++ b/libmp3/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Library for decoding and streaming MP3 audio
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmp3
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmp3 \
+                    https://github.com/KallistiOS/libmp3.git
 
 TARGET =            libmp3.a
 INSTALLED_HDRS =    include/sndmp3.h include/sndserver.h

--- a/libmp3/Makefile
+++ b/libmp3/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Library for decoding and streaming MP3 audio
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libmp3 \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libmp3 \
                     https://github.com/KallistiOS/libmp3.git
 
 TARGET =            libmp3.a

--- a/liboggvorbisplay/Makefile
+++ b/liboggvorbisplay/Makefile
@@ -9,7 +9,7 @@ SHORT_DESC =        Ogg Vorbis audio streaming library
 DEPENDENCIES =      libvorbis
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/liboggvorbis \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/liboggvorbis \
                     https://github.com/KallistiOS/liboggvorbisplay.git
 
 TARGET =            liboggvorbisplay.a

--- a/liboggvorbisplay/Makefile
+++ b/liboggvorbisplay/Makefile
@@ -9,7 +9,8 @@ SHORT_DESC =        Ogg Vorbis audio streaming library
 DEPENDENCIES =      libvorbis
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/liboggvorbis
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/liboggvorbis \
+                    https://github.com/KallistiOS/liboggvorbisplay.git
 
 TARGET =            liboggvorbisplay.a
 INSTALLED_HDRS =    include/oggvorbis/sndoggvorbis.h

--- a/libopusplay/Makefile
+++ b/libopusplay/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Opus audio playback library
 DEPENDENCIES =      opusfile
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libopusplay \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libopusplay \
                     https://github.com/KallistiOS/libopusplay.git
 
 TARGET =            libopusplay.a

--- a/libopusplay/Makefile
+++ b/libopusplay/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Opus audio playback library
 DEPENDENCIES =      opusfile
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libopusplay
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libopusplay \
+                    https://github.com/KallistiOS/libopusplay.git
 
 TARGET =            libopusplay.a
 INSTALLED_HDRS =    opusplay.h

--- a/libparallax/Makefile
+++ b/libparallax/Makefile
@@ -9,7 +9,7 @@ SHORT_DESC =        Simple (mostly 2D) game API library
 DEPENDENCIES =      libpng libjpeg libkmg
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libparallax \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libparallax \
                     https://github.com/KallistiOS/libparallax.git
 
 TARGET =            libparallax.a

--- a/libparallax/Makefile
+++ b/libparallax/Makefile
@@ -9,7 +9,8 @@ SHORT_DESC =        Simple (mostly 2D) game API library
 DEPENDENCIES =      libpng libjpeg libkmg
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libparallax
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libparallax \
+                    https://github.com/KallistiOS/libparallax.git
 
 TARGET =            libparallax.a
 INSTALLED_HDRS =    include/color.h include/context.h include/dr.h \

--- a/libpcx/Makefile
+++ b/libpcx/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Library for decoding PCX images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libpcx
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libpcx \
+                    https://github.com/KallistiOS/libpcx.git
 
 TARGET =            libpcx.a
 INSTALLED_HDRS =    include/pcx.h

--- a/libpcx/Makefile
+++ b/libpcx/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Library for decoding PCX images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libpcx \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libpcx \
                     https://github.com/KallistiOS/libpcx.git
 
 TARGET =            libpcx.a

--- a/libtga/Makefile
+++ b/libtga/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Library for decoding TGA images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtga \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libtga \
                     https://github.com/KallistiOS/libtga.git
 
 TARGET =            libtga.a

--- a/libtga/Makefile
+++ b/libtga/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Library for decoding TGA images
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtga
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtga \
+                    https://github.com/KallistiOS/libtga.git
 
 TARGET =            libtga.a
 INSTALLED_HDRS =    include/tga.h

--- a/libtsunami/Makefile
+++ b/libtsunami/Makefile
@@ -9,7 +9,8 @@ SHORT_DESC =        C++ "scene graph" wrapper around libparallax
 DEPENDENCIES =      libparallax
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtsunami
+GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtsunami \
+                    https://github.com/KallistiOS/libtsunami.git
 
 TARGET =            libtsunami.a
 HDR_DIRECTORY =     include

--- a/libtsunami/Makefile
+++ b/libtsunami/Makefile
@@ -9,7 +9,7 @@ SHORT_DESC =        C++ "scene graph" wrapper around libparallax
 DEPENDENCIES =      libparallax
 
 # What files we need to download, and where from.
-GIT_REPOSITORY =    git://git.code.sf.net/p/cadcdev/libtsunami \
+GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libtsunami \
                     https://github.com/KallistiOS/libtsunami.git
 
 TARGET =            libtsunami.a


### PR DESCRIPTION
Retrieving any of the kos-ports from sf.net lately has been throwing this error:

```
Cloning into 'libkmg-2.0.0'...
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

At least 4 users have complained about the issue in the past day.

Given that @ljsebald added the ability to specify mirror URLs and uploaded Github-hosted mirrors, let's go ahead and add the URLs to the repo Makefiles.