### PR TITLE
Updated Lua version from 5.4.4 to 5.4.6.

### DIFF
--- a/lua/Makefile
+++ b/lua/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          lua
-PORTVERSION =       5.4.4
+PORTVERSION =       5.4.6
 
 MAINTAINER =        Falco Girgis (GyroVorbis)
 LICENSE =           MIT

--- a/lua/distinfo
+++ b/lua/distinfo
@@ -1,2 +1,2 @@
-SHA256 (lua-5.4.4.tar.gz) = 164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
-SIZE (lua-5.4.4.tar.gz) = 360876
+SHA256 (lua-5.4.6.tar.gz) = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+SIZE (lua-5.4.6.tar.gz) = 363329


### PR DESCRIPTION
SOMEHOW I completely and totally missed out on Lua5.4.5 and Lua5.4.6.... I have immediately rectified the problem and have updated our antique Lua version to the latest, testing that it looks good!

![Screenshot from 2024-01-09 18-38-50](https://github.com/KallistiOS/kos-ports/assets/5545520/c51ebddc-d317-4326-a12a-916f1dc89c91)

There are actually a bunch of minor bugfixes that have been added since these last two point versions:
https://www.lua.org/bugs.html#5.4.6