### PR TITLE
Update zlib to 1.3.1

### DIFF
--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          zlib
-PORTVERSION =       1.3
+PORTVERSION =       1.3.1
 
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib

--- a/zlib/distinfo
+++ b/zlib/distinfo
@@ -1,2 +1,2 @@
-SHA256 (zlib-1.3.tar.gz) = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
-SIZE (zlib-1.3.tar.gz) = 1495873
+SHA256 (zlib-1.3.1.tar.gz) = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+SIZE (zlib-1.3.1.tar.gz) = 1512791


### PR DESCRIPTION
Hi,
I tried to compile the kos ports today and got a file size difference error during the compilation of the zlib library, therefore the build failed. I had a look at it and saw that there is a newer version of the zlib library and updated the library to 1.3.1. After using the new version, the compilation of the kos ports work again.