### PR TITLE
PDCurses

### DIFF
--- a/PDCurses/Makefile
+++ b/PDCurses/Makefile
@@ -2,7 +2,7 @@
 PORTNAME = 			PDCurses
 PORTVERSION = 		master
 
-MAINTAINER =        Quzar
+MAINTAINER =        Donald Haase
 LICENSE =           Public Domain
 SHORT_DESC =        PDCurses
 

--- a/PDCurses/Makefile
+++ b/PDCurses/Makefile
@@ -1,23 +1,23 @@
 # Port Metadata
-PORTNAME = 			PDCurses
-PORTVERSION = 		master
+PORTNAME =          libpdcurses
+PORTVERSION =       1.0.0
 
 MAINTAINER =        Donald Haase
 LICENSE =           Public Domain
-SHORT_DESC =        PDCurses
+SHORT_DESC =        PDCurses is a public domain curses library
 
 # Requires SDL1 for now
 DEPENDENCIES = SDL
 
 # What files we need to download, and where from.
-GIT_REPOSITORY = 	https://github.com/wmcbrine/PDCurses.git
+GIT_REPOSITORY =    https://github.com/wmcbrine/PDCurses.git
 
-TARGET =			libPDCurses.a
+TARGET =            libpdcurses.a
 INSTALLED_HDRS =    curses.h
 HDR_INSTDIR =       PDCurses
 EXAMPLES_DIR =      demos
 
 # KOS Distributed extras (to be copied into the build tree)
-KOS_DISTFILES =		KOSMakefile.mk
+KOS_DISTFILES =     KOSMakefile.mk
 
 include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/PDCurses/Makefile
+++ b/PDCurses/Makefile
@@ -1,0 +1,23 @@
+# Port Metadata
+PORTNAME = 			PDCurses
+PORTVERSION = 		master
+
+MAINTAINER =        Quzar
+LICENSE =           Public Domain
+SHORT_DESC =        PDCurses
+
+# Requires SDL1 for now
+DEPENDENCIES = SDL
+
+# What files we need to download, and where from.
+GIT_REPOSITORY = 	https://github.com/wmcbrine/PDCurses.git
+
+TARGET =			libPDCurses.a
+INSTALLED_HDRS =    curses.h
+HDR_INSTDIR =       PDCurses
+EXAMPLES_DIR =      demos
+
+# KOS Distributed extras (to be copied into the build tree)
+KOS_DISTFILES =		KOSMakefile.mk
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/PDCurses/files/KOSMakefile.mk
+++ b/PDCurses/files/KOSMakefile.mk
@@ -1,0 +1,48 @@
+# Makefile for PDCurses for SDL on KOS
+
+PDCURSES_SRCDIR = .
+
+O = o
+
+include $(PDCURSES_SRCDIR)/common/libobjs.mif
+
+osdir		= $(PDCURSES_SRCDIR)/sdl1
+
+PDCURSES_SDL_H	= $(osdir)/pdcsdl.h
+
+ifeq ($(DEBUG),Y)
+	CFLAGS  = $(KOS_CFLAGS) -DPDCDEBUG
+else
+	CFLAGS  = $(KOS_CFLAGS)
+endif
+
+ifeq ($(UTF8),Y)
+	CFLAGS	+= -DPDC_FORCE_UTF8
+endif
+
+BUILD		= kos-cc $(CFLAGS) -I$(KOS_PORTS)/include/SDL -I$(PDCURSES_SRCDIR)
+
+LDFLAGS		= $(LIBCURSES) -lSDL
+RANLIB		= ranlib
+LIBCURSES	= libPDCurses.a
+
+.PHONY: all clean
+
+all:	$(LIBCURSES)
+
+clean:
+	-rm -rf *.o $(LIBCURSES)
+
+$(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
+	ar rv $@ $?
+	-$(RANLIB) $@
+
+$(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
+$(PDCOBJS) : $(PDCURSES_SDL_H)
+
+$(LIBOBJS) : %.o: $(srcdir)/%.c
+	$(BUILD) -c $<
+
+$(PDCOBJS) : %.o: $(osdir)/%.c
+	$(BUILD) -c $<
+

--- a/PDCurses/files/KOSMakefile.mk
+++ b/PDCurses/files/KOSMakefile.mk
@@ -24,7 +24,7 @@ BUILD		= kos-cc $(CFLAGS) -I$(KOS_PORTS)/include/SDL -I$(PDCURSES_SRCDIR)
 
 LDFLAGS		= $(LIBCURSES) -lSDL
 RANLIB		= ranlib
-LIBCURSES	= libPDCurses.a
+LIBCURSES	= libpdcurses.a
 
 .PHONY: all clean
 

--- a/PDCurses/pkg-descr
+++ b/PDCurses/pkg-descr
@@ -1,0 +1,7 @@
+PDCurses is a public domain curses library for DOS, OS/2, Windows console, 
+X11 and SDL, implementing most of the functions available in X/Open and 
+System V R4 curses, and supporting a variety of compilers for these platforms. 
+The X11 and SDL ports let you recompile existing text-mode curses programs to 
+produce GUI applications.
+
+URL: https://pdcurses.org/


### PR DESCRIPTION
This is a public domain implementation of 'curses' the classic console IO lib https://pdcurses.org/ . Porting the SDL-backed version of it required no changes at all. This could be used to enable the easy porting/writing of console/text-based software.

It comes with a pile of examples and I set those up to be copied into the examples DIR, but wasn't sure how to set them up for building since there's no preexisting sample of a port with examples. I guess there could be a single KOSExamples.mk makefile or similar to build all of them at once?

If anyone would like to pick it up (I doubt I'll find the time) a native port shouldn't be too difficult.