### PR TITLE
Initial commit of SDL_ttf

### DIFF
--- a/SDL_ttf/Makefile
+++ b/SDL_ttf/Makefile
@@ -24,7 +24,7 @@ TARGET =            libSDL_ttf.a
 #There's no option in the build scripts to copy into a different ports inst/include so 
 # instead I'm abusing the fact that INSTALLED_HDRS and HDR_DIRECTORY aren't mutually exclusive.
 INSTALLED_HDRS =        SDL_ttf.h
-HDR_DIRECTORY =         ../../../SDL/inst/include
+HDR_DIRECTORY =         ../../../include/SDL
 HDR_INSTDIR =           SDL
 
 

--- a/SDL_ttf/Makefile
+++ b/SDL_ttf/Makefile
@@ -1,0 +1,40 @@
+# Port Metadata
+PORTNAME =          SDL_ttf
+PORTVERSION =       1.2
+
+MAINTAINER =        Donald Haase
+LICENSE =           zlib License - http://opensource.org/licenses/Zlib
+SHORT_DESC =        SDL TrueType font library
+
+# This port uses the autotools scripts that are included with the distfiles.
+PORT_AUTOTOOLS =    1
+
+# Don't attempt to copy the target library, it will be in the inst dir already.
+NOCOPY_TARGET =     1
+
+# No dependencies beyond the base system.
+DEPENDENCIES =      SDL libbz2 zlib libpng freetype
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/libsdl-org/SDL_ttf.git
+GIT_BRANCH =        SDL-1.2
+
+TARGET =            libSDL_ttf.a
+#There's a problem here. Standard SDL_ttf will install SDL_ttf.h into the SDL folder. 
+#There's no option in the build scripts to copy into a different ports inst/include so 
+# instead I'm abusing the fact that INSTALLED_HDRS and HDR_DIRECTORY aren't mutually exclusive.
+INSTALLED_HDRS =        SDL_ttf.h
+HDR_DIRECTORY =         ../../../SDL/inst/include
+HDR_INSTDIR =           SDL
+
+
+# Autotools setup work.
+CONFIGURE_ARGS =    
+CONFIGURE_DEFS =    SDL_CFLAGS=-I${KOS_PORTS}/include/SDL SDL_LIBS=-lSDL \
+                    FT2_CFLAGS="-I${KOS_PORTS}/include/zlib -I${KOS_PORTS}/include/bzlib \
+                    -I${KOS_PORTS}/include/png -I${KOS_PORTS}/include/freetype2" \
+                    FT2_LIBS="-lfreetype -lz -lbz2 -lpng -lm"
+MAKE_TARGET =       all install
+
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/SDL_ttf/pkg-descr
+++ b/SDL_ttf/pkg-descr
@@ -1,0 +1,3 @@
+SDL_ttf is a TrueType font rendering library that is used with the SDL library, and almost as portable. It depends on freetype2 to handle the TrueType font data. It allows a programmer to use multiple TrueType fonts without having to code a font rendering routine themselves. With the power of outline fonts and antialiasing, high quality text output can be obtained without much effort.
+
+URL: https://github.com/libsdl-org/SDL_ttf


### PR DESCRIPTION
Since we already have freetype and SDL, this was quite simple. The only caveat, which might (more properly) need an update to the kos-ports scripts, is the header for it. Normally SDL_ttf.h is installed into the same folder as SDL's general headers. The kos-ports scripts have no functionality for this that I could find, so instead I pull the existing SDL headers into the SDL_ttf inst folder and re-link to it as SDL.

Some part of this also creates a duplicated inst/include/SDL/SDL_ttf.h

Hopefully someone may have some suggestions on how to clean that up a bit, but if not it still just works (if a bit messy).