### PR TITLE
Update build to allow cmake, initial port of cglm

### DIFF
--- a/cglm/Makefile
+++ b/cglm/Makefile
@@ -1,0 +1,26 @@
+# Port Metadata
+PORTNAME =          cglm
+PORTVERSION =       1.0.0
+
+MAINTAINER =        Donald Haase
+LICENSE =           MIT
+SHORT_DESC =        Highly optimized 2D|3D math library, also known as OpenGL Mathematics (glm) for `C`
+
+# This port uses the autotools scripts that are included with the distfiles.
+PORT_BUILD =        cmake
+
+# Don't attempt to copy the target library, it will be in the inst dir already.
+NOCOPY_TARGET =     1
+
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/recp/cglm.git
+HDR_FULLDIR =       cglm
+TARGET =            libcglm.a
+EXAMPLES_DIR =      test
+
+# cmake setup work.
+CMAKE_ARGS =        -DCGLM_STATIC=ON
+MAKE_TARGET =       all install
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/cglm/pkg-descr
+++ b/cglm/pkg-descr
@@ -1,0 +1,7 @@
+cglm is an optimized 3D math library written in C99 (compatible with C89). 
+It is similar to the original glm library, except cglm is mainly for C.
+
+cglm stores matrices as column-major order but in the future row-major is 
+considered to be supported as optional.
+
+URL: https://github.com/recp/cglm

--- a/expat/Makefile
+++ b/expat/Makefile
@@ -7,7 +7,7 @@ LICENSE =           MIT (see COPYING in the source distribution)
 SHORT_DESC =        A C library for parsing XML
 
 # This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
+PORT_BUILD =        autotools
 
 # Don't attempt to copy the target library, it will be in the inst dir already.
 NOCOPY_TARGET =     1

--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -7,7 +7,7 @@ LICENSE =           FreeType License or GPLv2 (see docs/LICENSE.TXT in the sourc
 SHORT_DESC =        Freely available software library to render fonts of various types.
 
 # This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
+PORT_BUILD =        autotools
 
 # Don't attempt to copy the target library, it will be in the inst dir already.
 NOCOPY_TARGET =     1

--- a/libchipmunk/Makefile
+++ b/libchipmunk/Makefile
@@ -1,0 +1,35 @@
+# Port Metadata
+PORTNAME =          chipmunk
+PORTVERSION =       7.0.3.1
+
+MAINTAINER =        Donald Haase
+LICENSE =           MIT
+SHORT_DESC =        A fast and lightweight 2D game physics library.
+
+# This port uses the autotools scripts that are included with the distfiles.
+PORT_BUILD =        cmake
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/slembcke/Chipmunk2D.git
+#Official Chipmunk 7.0.3 does not build, so building straight from master
+#GIT_BRANCH =        Chipmunk-$(PORTVERSION)
+TARGET =            libchipmunk.a
+
+# This is required because the built-in cmake doesn't support custom install 
+# of headers. It does support custom installation of the lib itself via 
+# -DINSTALL_STATIC=ON and -DLIB_INSTALL_DIR=${KOS_PORTS}/${PORTNAME}/inst/lib 
+# But that forces the attempt to install the headers locally.
+HDR_DIRECTORY =     include/chipmunk
+
+# If the header installation issue above is fixed then install_static can be changed
+# Build_demos is reliant on a built-in library sokol that doesn't have a DC port
+CMAKE_ARGS =        -DBUILD_STATIC=ON -DBUILD_SHARED=OFF -DBUILD_DEMOS=OFF -DINSTALL_STATIC=OFF
+
+# Add a pre-install target to get the built library where we expect it.
+# This, copied from opus, might be solvable by 
+# adding an equivalent to HDR_DIRECTORY for lib
+PREINSTALL = chipmunk_preinstall
+chipmunk_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/src/${TARGET} build/${PORTNAME}-${PORTVERSION}
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libchipmunk/pkg-descr
+++ b/libchipmunk/pkg-descr
@@ -1,0 +1,6 @@
+Chipmunk2D is a simple, lightweight, fast and portable 2D rigid body 
+physics library written in C. It’s licensed under the unrestrictive, 
+OSI approved MIT license. Hundreds of shipping games have chosen Chipmunk 
+because of the high quality, speed, and accuracy of its 2D physics simulations.
+
+URL: https://chipmunk-physics.net/

--- a/libcmark/Makefile
+++ b/libcmark/Makefile
@@ -1,0 +1,31 @@
+# Port Metadata
+PORTNAME =          libcmark
+PORTVERSION =       0.31.0
+
+MAINTAINER =        Donald Haase
+LICENSE =           Custom (see the file COPYING provided with headers or at https://github.com/commonmark/cmark/blob/master/COPYING)
+SHORT_DESC =        CommonMark parsing and rendering library and program in C 
+
+# This port uses the autotools scripts that are included with the distfiles.
+PORT_BUILD =        cmake
+
+# This directs the behavior of creating a subdirectory 'build' and executing cmake at '..'
+CMAKE_OUTSOURCE = 1
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/commonmark/cmark.git
+GIT_BRANCH =        ${PORTVERSION}
+TARGET =            libcmark.a
+
+INSTALLED_HDRS =    src/*.h COPYING
+
+CMAKE_ARGS =        -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
+
+# Add a pre-install target to get the built library where we expect it.
+# This, copied from opus, might be solvable by 
+# adding an equivalent to HDR_DIRECTORY for lib
+PREINSTALL = cmark_preinstall
+cmark_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/build/src/${TARGET} build/${PORTNAME}-${PORTVERSION}
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libcmark/pkg-descr
+++ b/libcmark/pkg-descr
@@ -1,0 +1,9 @@
+cmark is the C reference implementation of CommonMark, a rationalized 
+version of Markdown syntax with a spec.
+
+It provides a shared library (libcmark) with functions for parsing 
+CommonMark documents to an abstract syntax tree (AST), manipulating 
+the AST, and rendering the document to HTML, groff man, LaTeX, 
+CommonMark, or an XML representation of the AST. 
+
+URL: https://commonmark.org/

--- a/libyaml/Makefile
+++ b/libyaml/Makefile
@@ -7,7 +7,7 @@ LICENSE =           MIT (see License in the source distribution)
 SHORT_DESC =        A C library for parsing and emitting YAML
 
 # This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
+PORT_BUILD =        autotools
 
 # Don't attempt to copy the target library, it will be in the inst dir already.
 NOCOPY_TARGET =     1

--- a/opus/Makefile
+++ b/opus/Makefile
@@ -7,7 +7,7 @@ LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Opus audio codec library
 
 # This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
+PORT_BUILD =        autotools
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/opusfile/Makefile
+++ b/opusfile/Makefile
@@ -7,7 +7,7 @@ LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Opus audio codec library high-level file access library
 
 # This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
+PORT_BUILD =        autotools
 
 # This port requires opus and libogg
 DEPENDENCIES =      opus libogg

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -6,15 +6,7 @@
 
 KOS_MAKEFILE ?= KOSMakefile.mk
 
-ifneq ($(PORT_AUTOTOOLS), 1)
-build-stamp: fetch validate-dist unpack copy-kos-files
-	@if [ -z "${DISTFILE_DIR}" ] ; then \
-		$(MAKE) -C build/${PORTNAME}-${PORTVERSION} -f ${KOS_MAKEFILE} ; \
-	else \
-		$(MAKE) -C build/${DISTFILE_DIR} -f ${KOS_MAKEFILE} ; \
-	fi
-	touch build-stamp
-else
+ifeq ($(PORT_BUILD), autotools)
 build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		cd build/${PORTNAME}-${PORTVERSION} ; \
@@ -24,6 +16,30 @@ build-stamp: fetch validate-dist unpack copy-kos-files
 		cd build/${DISTFILE_DIR} ; \
 		CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
 		$(MAKE) ${MAKE_TARGET} ; \
+	fi
+	touch build-stamp
+else ifeq ($(PORT_BUILD), cmake)
+build-stamp: fetch validate-dist unpack copy-kos-files
+	@if [ -z "${DISTFILE_DIR}" ] ; then \
+		cd build/${PORTNAME}-${PORTVERSION} ; \
+		cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
+			-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
+			-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib ${CMAKE_ARGS}; \
+		$(MAKE) ${MAKE_TARGET} ; \
+	else \
+		cd build/${DISTFILE_DIR} ; \
+		cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
+			-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
+			-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib ${CMAKE_ARGS}; \
+		$(MAKE) ${MAKE_TARGET} ; \
+	fi
+	touch build-stamp
+else
+build-stamp: fetch validate-dist unpack copy-kos-files
+	@if [ -z "${DISTFILE_DIR}" ] ; then \
+		$(MAKE) -C build/${PORTNAME}-${PORTVERSION} -f ${KOS_MAKEFILE} ; \
+	else \
+		$(MAKE) -C build/${DISTFILE_DIR} -f ${KOS_MAKEFILE} ; \
 	fi
 	touch build-stamp
 endif

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -6,8 +6,8 @@
 
 KOS_MAKEFILE ?= KOSMakefile.mk
 
+build-stamp: fetch validate-dist unpack copy-kos-files $(PREBUILD)
 ifeq ($(PORT_BUILD), autotools)
-build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		cd build/${PORTNAME}-${PORTVERSION} ; \
 	else \
@@ -15,9 +15,7 @@ build-stamp: fetch validate-dist unpack copy-kos-files
 	fi ; \
 	CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
 	$(MAKE) ${MAKE_TARGET} ;
-	touch build-stamp
 else ifeq ($(PORT_BUILD), cmake)
-build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		cd build/${PORTNAME}-${PORTVERSION} ; \
 	else \
@@ -33,17 +31,14 @@ build-stamp: fetch validate-dist unpack copy-kos-files
 		-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
 		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib $$p ${CMAKE_ARGS} ; \
 	$(MAKE) ${MAKE_TARGET} ;
-
-	touch build-stamp
 else
-build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		$(MAKE) -C build/${PORTNAME}-${PORTVERSION} -f ${KOS_MAKEFILE} ; \
 	else \
 		$(MAKE) -C build/${DISTFILE_DIR} -f ${KOS_MAKEFILE} ; \
 	fi
-	touch build-stamp
 endif
+	touch build-stamp
 
 install: setup-check version-check depends-check force-install
 

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -10,29 +10,30 @@ ifeq ($(PORT_BUILD), autotools)
 build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		cd build/${PORTNAME}-${PORTVERSION} ; \
-		CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
-		$(MAKE) ${MAKE_TARGET} ; \
 	else \
 		cd build/${DISTFILE_DIR} ; \
-		CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
-		$(MAKE) ${MAKE_TARGET} ; \
-	fi
+	fi ; \
+	CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
+	$(MAKE) ${MAKE_TARGET} ;
 	touch build-stamp
 else ifeq ($(PORT_BUILD), cmake)
 build-stamp: fetch validate-dist unpack copy-kos-files
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
 		cd build/${PORTNAME}-${PORTVERSION} ; \
-		cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
-			-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
-			-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib ${CMAKE_ARGS}; \
-		$(MAKE) ${MAKE_TARGET} ; \
 	else \
 		cd build/${DISTFILE_DIR} ; \
-		cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
-			-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
-			-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib ${CMAKE_ARGS}; \
-		$(MAKE) ${MAKE_TARGET} ; \
-	fi
+	fi ; \
+	if [ -z "${CMAKE_OUTSOURCE}" ] ; then \
+		p=. ; \
+	else \
+		mkdir build ; cd build ; \
+		p=.. ; \
+	fi ; \
+	cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
+		-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
+		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib $$p ${CMAKE_ARGS} ; \
+	$(MAKE) ${MAKE_TARGET} ;
+
 	touch build-stamp
 else
 build-stamp: fetch validate-dist unpack copy-kos-files


### PR DESCRIPTION
This is a proposed update of the build.mk kos-ports scripts to allow cmake as an optional build system (alongside autotools). Instead of a flag for 'PORT_AUTOTOOLS', now there is a variable to set 'PORT_BUILD' that can be set to autotools or cmake (and would be open to expansion in the future).

I'm not very familiar with the way cmake works and I think that the values I'm passing in manually in build.mk may well belong more in the base cmake scripts since they would be global to the kos/kos-ports environment:

-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include
-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib 

Another thing is that this would, without some other work, make cmake a dependency for kos-ports. configure already is so perhaps that's not bad, but some help would probably be good in making sure it can soft-fail and still let people without cmake build the rest.

Making this update required updating the makefiles for the existing ports that relied on the PORT_AUTOTOOLS flag to use the new scheme.

Additionally I provided a sample port of [cglm](https://github.com/recp/cglm), an OpenGL math library, which uses cmake and is buildable with this (including using cmake to build the tests that are provided into the examples folder).

Update: I've now also introduced a new option "CMAKE_OUTSOURCE". When defined, it sets the behavior to automatically create a build folder and build from it. This seemed fairly common when I was surveying software using cmake, but perhaps has a standard name or should take a parameter for the path name?

Additionally I've added 2 other ports that help demonstrate the functionalities and possible additional work needed: [Chipmunk2D](https://github.com/slembcke/Chipmunk2D) and [cmark](https://github.com/commonmark/cmark/) Both required a fixup to get the build library to where its expected and cmark required the OUTSOURCE functionality.

Update2: One additional option that I've added is PREBUILD. This is a counterpart to PREINSTALL and allows similarly adding directives, but that will happen directly before cmake/configure/make are called. This is needed, for instance, for autotools ports that require running an `autogen.sh` first.