### PR TITLE
Updating SDL_ttf to not use autotools

### DIFF
--- a/SDL_ttf/Makefile
+++ b/SDL_ttf/Makefile
@@ -6,11 +6,9 @@ MAINTAINER =        Donald Haase
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib
 SHORT_DESC =        SDL TrueType font library
 
-# This port uses the autotools scripts that are included with the distfiles.
-PORT_AUTOTOOLS =    1
-
-# Don't attempt to copy the target library, it will be in the inst dir already.
-NOCOPY_TARGET =     1
+# This port could use autotools, but it tries to build the glfont example which uses
+# functionality currently unsupported by gldc..
+#PORT_AUTOTOOLS =    1
 
 # No dependencies beyond the base system.
 DEPENDENCIES =      SDL libbz2 zlib libpng freetype
@@ -27,14 +25,7 @@ INSTALLED_HDRS =        SDL_ttf.h
 HDR_DIRECTORY =         ../../../include/SDL
 HDR_INSTDIR =           SDL
 
-
-# Autotools setup work.
-CONFIGURE_ARGS =    
-CONFIGURE_DEFS =    SDL_CFLAGS=-I${KOS_PORTS}/include/SDL SDL_LIBS=-lSDL \
-                    FT2_CFLAGS="-I${KOS_PORTS}/include/zlib -I${KOS_PORTS}/include/bzlib \
-                    -I${KOS_PORTS}/include/png -I${KOS_PORTS}/include/freetype2" \
-                    FT2_LIBS="-lfreetype -lz -lbz2 -lpng -lm"
-MAKE_TARGET =       all install
-
+#KOS Distributed extras (to be copied into the build tree)
+KOS_DISTFILES =     KOSMakefile.mk
 
 include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/SDL_ttf/files/KOSMakefile.mk
+++ b/SDL_ttf/files/KOSMakefile.mk
@@ -1,0 +1,10 @@
+TARGET = libSDL_ttf.a
+OBJS = SDL_ttf.o
+
+KOS_CFLAGS += -I. \
+	-I${KOS_PORTS}/include/SDL -lSDL \
+	-I${KOS_PORTS}/include/zlib -I${KOS_PORTS}/include/bzlib \
+	-I${KOS_PORTS}/include/png -I${KOS_PORTS}/include/freetype2 \
+	-lfreetype -lz -lbz2 -lpng -lm
+
+include ${KOS_PORTS}/scripts/lib.mk


### PR DESCRIPTION
The previous version worked as long as there was no ogl installed on the host system because autotools would believe that there was none available generally and not build the glfont example. The example relies on the glAttribute stack which we don't currently support in gldc.

If we ever do, then this should be updated to build that glfont examples and put it in the examples folder.