### PR TITLE
Initial commit of BearSSL port

### DIFF
--- a/libbearssl/Makefile
+++ b/libbearssl/Makefile
@@ -1,0 +1,23 @@
+# Port Metadata
+PORTNAME =          libbearssl
+PORTVERSION =       1.0.0
+
+MAINTAINER =        Donald Haase
+LICENSE =           MIT License
+SHORT_DESC =        BearSSL is an implementation of the SSL/TLS protocol (RFC 5246) written in C.
+
+KOS_MAKEFILE = Makefile
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://www.bearssl.org/git/BearSSL
+TARGET =            libbearssl.a
+HDR_DIRECTORY =     inc
+
+# Add a pre-install target to get the built library where we expect it.
+PREINSTALL = bearssl_preinstall
+bearssl_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/build/${TARGET} build/${PORTNAME}-${PORTVERSION}
+
+MAKE_TARGET =       all install
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libbearssl/pkg-descr
+++ b/libbearssl/pkg-descr
@@ -1,0 +1,22 @@
+BearSSL is an implementation of the SSL/TLS protocol (RFC 5246) written in C. 
+It aims at offering the following features:
+
+    Be correct and secure. In particular, insecure protocol versions and 
+    choices of algorithms are not supported, by design; cryptographic 
+    algorithm implementations are constant-time by default.
+
+    Be small, both in RAM and code footprint. For instance, a minimal server 
+    implementation may fit in about 20 kilobytes of compiled code and 
+    25 kilobytes of RAM.
+
+    Be highly portable. BearSSL targets not only “big” operating systems like 
+    Linux and Windows, but also small embedded systems and even special 
+    contexts like bootstrap code.
+
+    Be feature-rich and extensible. SSL/TLS has many defined cipher suites 
+    and extensions; BearSSL should implement most of them, and allow extra 
+    algorithm implementations to be added afterwards, possibly from third 
+    parties.
+
+
+URL: https://bearssl.org/


### PR DESCRIPTION
As on the tin. Unfortunately don't have any sample use cases. It may be worthwhile to add an http(s)d example to go alongside httpd (or enhance it to optionally/additionally build with SSL if available)