### PR TITLE
Rework build-all.sh

### DIFF
--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -35,5 +35,6 @@ done
 
 if [ -n "$errors" ]; then
     echo "\n------------------------------------------"
-    echo "$error_count Error(s) occurred during the build process:\n$errors"
+    echo "$error_count Error(s) occurred during the build process:"
+    echo "$errors"
 fi

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -3,10 +3,12 @@
 #
 # utils/build-all.mk
 # Copyright (C) 2015 Lawrence Sebald
+# Copyright (C) 2024 Andy Barajas
 #
 
 cd ${KOS_PORTS}
 errors=""
+error_count=0
 
 for _dir in ${KOS_PORTS}/* ; do
     if [ -d "${_dir}" ] ; then
@@ -22,6 +24,7 @@ for _dir in ${KOS_PORTS}/* ; do
                 if [ "$rv" -ne 0 ] ; then
                     echo "Error building ${_dir}."
                     errors="${errors}${_dir}: Build failed with return code ${rv}\n"
+                    error_count=$((error_count + 1))
                 fi
             else
                 echo "${_dir} is already installed and up-to-date. Skipping."
@@ -31,5 +34,6 @@ for _dir in ${KOS_PORTS}/* ; do
 done
 
 if [ -n "$errors" ]; then
-    echo "\n\nErrors occurred during the build process:\n$errors"
+    echo "\n------------------------------------------"
+    echo "$error_count Error(s) occurred during the build process:\n$errors"
 fi

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -6,6 +6,7 @@
 #
 
 cd ${KOS_PORTS}
+errors=""
 
 for _dir in ${KOS_PORTS}/* ; do
     if [ -d "${_dir}" ] ; then
@@ -19,8 +20,8 @@ for _dir in ${KOS_PORTS}/* ; do
                 rv=$?
                 echo $rv
                 if [ "$rv" -ne 0 ] ; then
-                    echo "Error building ${_dir}. Bailing out."
-                    exit 1
+                    echo "Error building ${_dir}."
+                    errors="${errors}${_dir}: Build failed with return code ${rv}\n"
                 fi
             else
                 echo "${_dir} is already installed and up-to-date. Skipping."
@@ -28,3 +29,7 @@ for _dir in ${KOS_PORTS}/* ; do
         fi
     fi
 done
+
+if [ -n "$errors" ]; then
+    echo "\n\nErrors occurred during the build process:\n$errors"
+fi

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -10,7 +10,7 @@ cd ${KOS_PORTS}
 errors=""
 error_count=0
 
-for _dir in ${KOS_PORTS}/* ; do
+for _dir in $(realpath ${KOS_PORTS})/* ; do
     if [ -d "${_dir}" ] ; then
         if [ -f "${_dir}/Makefile" ] ; then
             echo "Checking if ${_dir} is installed and up-to-date..."
@@ -35,6 +35,6 @@ done
 
 if [ -n "$errors" ]; then
     echo "\n-------------------------------------------------"
-    echo "$error_count Error(s) occurred during the build process:"
+    echo "$error_count error(s) occurred during the build process:"
     echo "$errors"
 fi

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -34,7 +34,7 @@ for _dir in ${KOS_PORTS}/* ; do
 done
 
 if [ -n "$errors" ]; then
-    echo "\n------------------------------------------"
+    echo "\n-------------------------------------------------"
     echo "$error_count Error(s) occurred during the build process:"
     echo "$errors"
 fi

--- a/utils/calc_dist.py
+++ b/utils/calc_dist.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # kos-ports ##version##
 #
-# scripts/calc_dist.py
+# utils/calc_dist.py
 # Copyright (C) 2015 Lawrence Sebald
 #
 

--- a/utils/clean-all.sh
+++ b/utils/clean-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # kos-ports ##version##
 #
-# utils/clean-all.mk
+# utils/clean-all.sh
 # Copyright (C) 2015 Lawrence Sebald
 #
 

--- a/utils/uninstall-all.sh
+++ b/utils/uninstall-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # kos-ports ##version##
 #
-# scripts/uninstall-all.mk
+# utils/uninstall-all.sh
 # Copyright (C) 2015 Lawrence Sebald
 #
 


### PR DESCRIPTION
kos-ports has always stopped building when one port fails to build.  Now we try and build everything first and then display errors at the end.  Example output:

```

------------------------------------------
1 Error(s) occurred during the build process:
/opt/toolchains/dc/kos/../kos-ports/mruby: Build failed with return code 2
```