### PR TITLE
realpath does not exist on mac

### DIFF
--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -10,7 +10,7 @@ cd ${KOS_PORTS}
 errors=""
 error_count=0
 
-for _dir in $(realpath ${KOS_PORTS})/* ; do
+for _dir in ${KOS_PORTS}/* ; do
     if [ -d "${_dir}" ] ; then
         if [ -f "${_dir}/Makefile" ] ; then
             echo "Checking if ${_dir} is installed and up-to-date..."


### PR DESCRIPTION
realpath does not work on MacOS without installing a brew package.  realpath was used to make:

/opt/toolchains/dc/kos/../kos-ports/mruby look like /opt/toolchains/dc/kos-ports/mruby 

A fix is available in the environ.sh file in KOS repo here: https://github.com/KallistiOS/KallistiOS/pull/556