### PR TITLE
Fix libtsunami building in legacy toolchain

### DIFF
--- a/libtsunami/files/KOSMakefile.mk
+++ b/libtsunami/files/KOSMakefile.mk
@@ -5,6 +5,6 @@ OBJS_ANIMS := $(patsubst %.cpp,%.o,$(wildcard src/anims/*.cpp))
 OBJS_TRIGS := $(patsubst %.cpp,%.o,$(wildcard src/triggers/*.cpp))
 OBJS := $(OBJS_MAIN) $(OBJS_DRW) $(OBJS_ANIMS) $(OBJS_TRIGS)
 
-KOS_CFLAGS += -Iinclude
+KOS_CFLAGS += -Iinclude -std=gnu++17
 
 include ${KOS_PORTS}/scripts/lib.mk


### PR DESCRIPTION
https://github.com/KallistiOS/libtsunami/pull/1 broke the building of libtsunami on the legacy toolchain. In our modern ones it seems it was having to ignore KOS' default `-std=gnu++98` in order to build.

Tested to now build correctly with the legacy and with experimental toolchain profiles.

I'm not 100% certain, but maybe this is something that should get added to libtsunami's makefiles as well?