### PR TITLE
Remove extraneous lm in SDL_ttf

### DIFF
--- a/SDL_ttf/files/KOSMakefile.mk
+++ b/SDL_ttf/files/KOSMakefile.mk
@@ -5,6 +5,6 @@ KOS_CFLAGS += -I. \
 	-I${KOS_PORTS}/include/SDL -lSDL \
 	-I${KOS_PORTS}/include/zlib -I${KOS_PORTS}/include/bzlib \
 	-I${KOS_PORTS}/include/png -I${KOS_PORTS}/include/freetype2 \
-	-lfreetype -lz -lbz2 -lpng -lm
+	-lfreetype -lz -lbz2 -lpng
 
 include ${KOS_PORTS}/scripts/lib.mk


### PR DESCRIPTION
I had to make sure to tack in on in the KOSMakefile here, now with https://github.com/KallistiOS/KallistiOS/pull/569 it's not necessary as it's automatically provided.