### PR TITLE
Return error code when build failure occurs

### DIFF
--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -38,3 +38,4 @@ if [ -n "$errors" ]; then
     echo "$error_count error(s) occurred during the build process:"
     echo "$errors"
 fi
+return $error_count


### PR DESCRIPTION
Makes it easier to tell if ports is failing to build in a scripted environment