### PR TITLE
Fix unsupported bash for MacOS

### DIFF
--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -38,4 +38,4 @@ if [ -n "$errors" ]; then
     echo "$error_count error(s) occurred during the build process:"
     echo "$errors"
 fi
-return $error_count
+exit $error_count


### PR DESCRIPTION
@DC-SWAT reported an issue on MacOS from the changes in https://github.com/KallistiOS/kos-ports/pull/69. MacOS uses an older version of bash that doesn't recognize the `return` keyword to exit a script. Switching to `exit` should resolve this issue.