### PR TITLE
Upgraded Lua to latest version 5.4.7.

### DIFF
--- a/lua/Makefile
+++ b/lua/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          lua
-PORTVERSION =       5.4.6
+PORTVERSION =       5.4.7
 
 MAINTAINER =        Falco Girgis (GyroVorbis)
 LICENSE =           MIT

--- a/lua/distinfo
+++ b/lua/distinfo
@@ -1,2 +1,2 @@
-SHA256 (lua-5.4.6.tar.gz) = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
-SIZE (lua-5.4.6.tar.gz) = 363329
+SHA256 (lua-5.4.7.tar.gz) = 9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
+SIZE (lua-5.4.7.tar.gz) = 374097


### PR DESCRIPTION
- Everything checks out fine.
- There was a bugfix to the REPL with multiline input... and the REPL happens to be our only KOS example. What a coincidence!