### PR TITLE
expat and libyaml: fix build with flto

### DIFF
--- a/expat/Makefile
+++ b/expat/Makefile
@@ -25,7 +25,7 @@ DISTFILE_DIR =      ${PORTNAME}-${PORTVERSION}
 
 # Autotools setup work.
 CONFIGURE_ARGS =
-CONFIGURE_DEFS =
+CONFIGURE_DEFS =    RANLIB=${KOS_RANLIB} AR=${KOS_AR}
 MAKE_TARGET =       all install
 
 # KOS Distributed extras (to be copied into the build tree)

--- a/libyaml/Makefile
+++ b/libyaml/Makefile
@@ -25,7 +25,7 @@ DISTFILE_DIR =      yaml-${PORTVERSION}
 
 # Autotools setup work.
 CONFIGURE_ARGS =
-CONFIGURE_DEFS =
+CONFIGURE_DEFS =    RANLIB=${KOS_RANLIB} AR=${KOS_AR}
 MAKE_TARGET =       all install
 
 # KOS Distributed extras (to be copied into the build tree)


### PR DESCRIPTION
When the KOS toolchain has been setup to build with flto expat will fail to link with the default ar and ranlib. So we'll use the gcc ones instead.