### PR TITLE
Add mirror for libjpeg

### DIFF
--- a/libjpeg/Makefile
+++ b/libjpeg/Makefile
@@ -10,7 +10,7 @@ SHORT_DESC =        Freely available lossy image compression library (with KOS a
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-DOWNLOAD_SITES =    http://xijg.org/files \
+DOWNLOAD_SITES =    http://ijg.org/files \
                     https://sources.buildroot.net/libjpeg/
 DOWNLOAD_FILES =    jpegsrc.v9e.tar.gz
 

--- a/libjpeg/Makefile
+++ b/libjpeg/Makefile
@@ -10,7 +10,8 @@ SHORT_DESC =        Freely available lossy image compression library (with KOS a
 DEPENDENCIES =
 
 # What files we need to download, and where from.
-DOWNLOAD_SITE =     http://ijg.org/files
+DOWNLOAD_SITES =    http://xijg.org/files \
+                    https://sources.buildroot.net/libjpeg/
 DOWNLOAD_FILES =    jpegsrc.v9e.tar.gz
 
 TARGET =            libjpeg.a


### PR DESCRIPTION
I was having issues building libjpeg (`ijg.org` was down), so I had to build it using a mirror.

Adding a mirror for future reference.