### PR TITLE
Provide alt url for freetype

### DIFF
--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -16,7 +16,8 @@ NOCOPY_TARGET =     1
 DEPENDENCIES =      libbz2 zlib libpng
 
 # What files we need to download, and where from.
-DOWNLOAD_SITE =     https://download.savannah.gnu.org/releases/freetype/
+DOWNLOAD_SITES =    https://download.savannah.gnu.org/releases/freetype/ \
+                    https://sourceforge.net/projects/freetype/files/freetype2/2.10.2/
 DOWNLOAD_FILES =    freetype-2.10.2.tar.gz
 
 TARGET =            libfreetype.a


### PR DESCRIPTION
Download from savannah gives problems sometimes, sourceforge is the official alt download url specified in http://freetype.org/download.html