### PR TITLE
Add port for libvldmail

### DIFF
--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -1,0 +1,21 @@
+# Port Metadata
+PORTNAME =          libvldmail
+PORTVERSION =       1.0.0
+
+MAINTAINER =        Donald Haase
+LICENSE =           MIT-0
+SHORT_DESC =        An e-mail address validation libarary.
+
+# This port uses the autotools scripts that are included with the distfiles.
+PORT_BUILD =        cmake
+
+# What files we need to download, and where from.
+GIT_REPOSITORY =    https://github.com/dertuxmalwieder/libvldmail.git
+TARGET =            libvldmail.a
+INSTALLED_HDRS =    src/vldmail.h
+
+#Passing this causes the test to be built as a .elf in the build dir.
+#It doesn't quite match the current scheme we have for 'examples'
+CMAKE_ARGS =        -DBUILD_THE_TEST=1
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -4,7 +4,7 @@ PORTVERSION =       1.0.0
 
 MAINTAINER =        Donald Haase
 LICENSE =           MIT-0
-SHORT_DESC =        An e-mail address validation libarary.
+SHORT_DESC =        An e-mail address validation library.
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        cmake

--- a/libvldmail/pkg-descr
+++ b/libvldmail/pkg-descr
@@ -1,0 +1,4 @@
+libvldmail is a simple library for validating email addresses as being
+valid based off various RFC standards.
+
+URL: https://github.com/dertuxmalwieder/libvldmail


### PR DESCRIPTION
As on tin. This is a small library that tests an email address for being valid (a task that is significantly more complex than it would seem). I left the option for it to build its sample enabled as an extra test that it can be linked, though it would need modification to work correctly on the DC.