### PR TITLE
Adjust .gitignore to ignore build and dist dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *~
 *.tmp
 build-stamp
+build/
+dist/
 include/*
 lib/*
 examples/*


### PR DESCRIPTION
Currently git will track the `build` and `dist` dirs if any ports were built.
This changes `.gitignore` so it no longer does that.