### PR TITLE
Use treeless clone when git repo is used as source

### DIFF
--- a/scripts/download.mk
+++ b/scripts/download.mk
@@ -41,21 +41,21 @@ fetch:
 				for _repo in $$_repos; do \
 					echo "Fetching ${PORTNAME} from $$_repo ..." ; \
 					if [ -n "${GIT_TAG}" ] ; then \
-						git clone $$_repo --branch ${GIT_TAG} --single-branch --depth 1 ${PORTNAME}-${PORTVERSION} ; \
+						git clone --filter=tree:0 $$_repo --branch ${GIT_TAG} --single-branch --depth 1 ${PORTNAME}-${PORTVERSION} ; \
 						if [ "$$?" -eq 0 ] ; then \
 							break; \
 						else \
 							rm -rf ${PORTNAME}-${PORTVERSION} ; \
 						fi ; \
 					elif [ -n "${GIT_BRANCH}" ] ; then \
-						git clone $$_repo --branch ${GIT_BRANCH} --single-branch ${PORTNAME}-${PORTVERSION} ; \
+						git clone --filter=tree:0 $$_repo --branch ${GIT_BRANCH} --single-branch ${PORTNAME}-${PORTVERSION} ; \
 						if [ "$$?" -eq 0 ] ; then \
 							break; \
 						else \
 							rm -rf ${PORTNAME}-${PORTVERSION} ; \
 						fi ; \
 					else \
-						git clone $$_repo ${PORTNAME}-${PORTVERSION} ; \
+						git clone --filter=tree:0 $$_repo ${PORTNAME}-${PORTVERSION} ; \
 						if [ "$$?" -eq 0 ] ; then \
 							break; \
 						else \


### PR DESCRIPTION
This change was requested by a few users. Similarly to [KallistiOS #525](https://github.com/KallistiOS/KallistiOS/pull/525)...

This cuts down drastically on the amount of data downloaded when building ports using git sources. Commit history is still downloaded so developers can `make fetch` sources and then checkout specific commit IDs, but the tree and blob data will be downloaded by the git client on demand in such case.