### PR TITLE
Add floating-point precision ABI check functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ the above operations on **all** ports in the tree:
 #### Lesser used targets (mainly for internal use):
 - **version-check**: Check the version of the port that is currently installed.
 - **depends-check**: Check if all dependencies of the port are installed.
+- **abi-check**: Check if the current KOS floating-point ABI is compatible.
 - **fetch**: Download dist files from upstream.
 - **validate-dist**: Check downloaded distfiles for validity, if enabled.
 - **unpack**: Unpack any fetched packages for the port.

--- a/config.mk
+++ b/config.mk
@@ -15,6 +15,10 @@ UNPACK_CMD = tar xf
 # recursively.
 BUILD_DEPENDS = true
 
+# Select whether or not to check if a port is compatible with KOS's current
+# floating-point precision ABI setting (KOS_SH4_PRECISION) before building.
+CHECK_PRECISION = true
+
 # Select whether or not to validate each file downloaded before unpacking them.
 # This requires Python to be installed.
 VALIDATE_DISTFILES = true

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -40,7 +40,7 @@ else
 endif
 	touch build-stamp
 
-install: setup-check version-check depends-check force-install
+install: setup-check version-check abi-check depends-check force-install
 
 force-install: build-stamp $(PREINSTALL)
 	@if [ ! -d "inst" ] ; then \

--- a/scripts/kos-ports.mk
+++ b/scripts/kos-ports.mk
@@ -17,6 +17,7 @@ include ${KOS_PORTS}/scripts/unpack.mk
 include ${KOS_PORTS}/scripts/clean.mk
 include ${KOS_PORTS}/scripts/build.mk
 include ${KOS_PORTS}/scripts/version.mk
+include ${KOS_PORTS}/scripts/precision.mk
 include ${KOS_PORTS}/scripts/depends.mk
 include ${KOS_PORTS}/scripts/uninstall.mk
 include ${KOS_PORTS}/scripts/portinfo.mk

--- a/scripts/precision.mk
+++ b/scripts/precision.mk
@@ -1,0 +1,30 @@
+# kos-ports ##version##
+#
+# scripts/precision.mk
+# Copyright (C) 2024 Eric Fradella
+#
+
+REQUIRES_ABI ?= any
+
+abi-check:
+ifeq (${CHECK_PRECISION},true)
+    ifeq (${REQUIRES_ABI},any)
+		@echo "${PORTNAME} is compatible with any floating-point ABI."
+    else
+		@case " $(REQUIRES_ABI) " in *" $(KOS_SH4_PRECISION) "*) \
+			echo "${PORTNAME} is compatible with the ${KOS_SH4_PRECISION} floating-point ABI."; \
+			;; \
+		*) \
+			echo "${PORTNAME} is not compatible with the ${KOS_SH4_PRECISION} floating-point ABI!"; \
+			echo "Change the KOS_SH4_PRECISION setting in your environ.sh to one of the following: ${REQUIRES_ABI}"; \
+			echo "Then rebuild KOS and try again."; \
+			exit 1; \
+			;; \
+		esac
+    endif
+else ifeq (${CHECK_PRECISION},false)
+	@echo "CHECK_PRECISION is disabled in config.mk. Skipping ABI compatibility check."
+else
+	@echo "CHECK_PRECISION is not set in config.mk. Please correct your configuration."
+	exit 1
+endif


### PR DESCRIPTION
In preparation for making `m4-single` the default for KOS, this PR adds a floating point ABI compatibility check function to kos-ports so that if a port is deemed incompatible with the current `KOS_SH4_PRECISION` setting, the kos-ports build system will display an error. 

- `CHECK_PRECISION` is added to `config.mk` to turn the check on or off. The default is on.
- `REQUIRES_ABI` is a new setting that can be added to a port's `Makefile`. If omitted, the setting will be assumed to be `any`. If `any`, the check always passes. Otherwise, a space-separated list of compatible ABIs can be specified, and the build system will check if the current `KOS_SH4_PRECISION` setting is contained within the list before building the port. If not, the port will fail to build.