### PR TITLE
Fix comments, formatting issues, and prebuild/preinstall target order

### DIFF
--- a/cglm/Makefile
+++ b/cglm/Makefile
@@ -6,7 +6,7 @@ MAINTAINER =        Donald Haase
 LICENSE =           MIT
 SHORT_DESC =        Highly optimized 2D|3D math library, also known as OpenGL Mathematics (glm) for `C`
 
-# This port uses the autotools scripts that are included with the distfiles.
+# This port uses CMake.
 PORT_BUILD =        cmake
 
 # Don't attempt to copy the target library, it will be in the inst dir already.

--- a/libbearssl/Makefile
+++ b/libbearssl/Makefile
@@ -15,9 +15,9 @@ HDR_DIRECTORY =     inc
 
 # Add a pre-install target to get the built library where we expect it.
 PREINSTALL = bearssl_preinstall
-bearssl_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/build/${TARGET} build/${PORTNAME}-${PORTVERSION}
 
 MAKE_TARGET =       all install
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+bearssl_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/build/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/libchipmunk/Makefile
+++ b/libchipmunk/Makefile
@@ -6,7 +6,7 @@ MAINTAINER =        Donald Haase
 LICENSE =           MIT
 SHORT_DESC =        A fast and lightweight 2D game physics library.
 
-# This port uses the autotools scripts that are included with the distfiles.
+# This port uses CMake.
 PORT_BUILD =        cmake
 
 # What files we need to download, and where from.
@@ -15,9 +15,9 @@ GIT_REPOSITORY =    https://github.com/slembcke/Chipmunk2D.git
 #GIT_BRANCH =        Chipmunk-$(PORTVERSION)
 TARGET =            libchipmunk.a
 
-# This is required because the built-in cmake doesn't support custom install 
-# of headers. It does support custom installation of the lib itself via 
-# -DINSTALL_STATIC=ON and -DLIB_INSTALL_DIR=${KOS_PORTS}/${PORTNAME}/inst/lib 
+# This is required because the built-in cmake doesn't support custom install
+# of headers. It does support custom installation of the lib itself via
+# -DINSTALL_STATIC=ON and -DLIB_INSTALL_DIR=${KOS_PORTS}/${PORTNAME}/inst/lib
 # But that forces the attempt to install the headers locally.
 HDR_DIRECTORY =     include/chipmunk
 
@@ -26,10 +26,10 @@ HDR_DIRECTORY =     include/chipmunk
 CMAKE_ARGS =        -DBUILD_STATIC=ON -DBUILD_SHARED=OFF -DBUILD_DEMOS=OFF -DINSTALL_STATIC=OFF
 
 # Add a pre-install target to get the built library where we expect it.
-# This, copied from opus, might be solvable by 
+# This, copied from opus, might be solvable by
 # adding an equivalent to HDR_DIRECTORY for lib
-PREINSTALL = chipmunk_preinstall
-chipmunk_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/src/${TARGET} build/${PORTNAME}-${PORTVERSION}
+PREINSTALL =        chipmunk_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+chipmunk_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/src/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/libcmark/Makefile
+++ b/libcmark/Makefile
@@ -4,13 +4,13 @@ PORTVERSION =       0.31.0
 
 MAINTAINER =        Donald Haase
 LICENSE =           Custom (see the file COPYING provided with headers or at https://github.com/commonmark/cmark/blob/master/COPYING)
-SHORT_DESC =        CommonMark parsing and rendering library and program in C 
+SHORT_DESC =        CommonMark parsing and rendering library and program in C
 
-# This port uses the autotools scripts that are included with the distfiles.
+# This port uses CMake.
 PORT_BUILD =        cmake
 
 # This directs the behavior of creating a subdirectory 'build' and executing cmake at '..'
-CMAKE_OUTSOURCE = 1
+CMAKE_OUTSOURCE =   1
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/commonmark/cmark.git
@@ -22,10 +22,10 @@ INSTALLED_HDRS =    src/*.h COPYING
 CMAKE_ARGS =        -DBUILD_SHARED_LIBS=NO -DBUILD_TESTING=NO
 
 # Add a pre-install target to get the built library where we expect it.
-# This, copied from opus, might be solvable by 
+# This, copied from opus, might be solvable by
 # adding an equivalent to HDR_DIRECTORY for lib
-PREINSTALL = cmark_preinstall
-cmark_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/build/src/${TARGET} build/${PORTNAME}-${PORTVERSION}
+PREINSTALL =        cmark_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+cmark_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/build/src/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -6,7 +6,7 @@ MAINTAINER =        Donald Haase
 LICENSE =           MIT-0
 SHORT_DESC =        An e-mail address validation library.
 
-# This port uses the autotools scripts that are included with the distfiles.
+# This port uses CMake.
 PORT_BUILD =        cmake
 
 # What files we need to download, and where from.

--- a/libzip/Makefile
+++ b/libzip/Makefile
@@ -20,24 +20,25 @@ TARGET =            libzip.a
 
 # Set cmake options
 CMAKE_ARGS =        -Wno-dev -DCMAKE_INSTALL_PREFIX=../../inst \
-        -DCMAKE_C_FLAGS="-I{$KOS_PORTS}/include/zlib" \
-        -DZLIB_INCLUDE_DIR="${KOS_PORTS}/include/zlib"
+                    -DCMAKE_C_FLAGS="-I{$KOS_PORTS}/include/zlib" \
+                    -DZLIB_INCLUDE_DIR="${KOS_PORTS}/include/zlib"
 
-MAKE_TARGET = zip
+MAKE_TARGET =       zip
 
 # Adjust the source code
-PREBUILD = libzip_prebuild
+PREBUILD =          libzip_prebuild
+
+# Add a pre-install target to get the built library where we expect it.
+# Copy the header files manually
+PREINSTALL =        libzip_preinstall
+
+include ${KOS_PORTS}/scripts/kos-ports.mk
 libzip_prebuild:
 	cd "build/${PORTNAME}-${PORTVERSION}" && \
 	patch -p1 < ../../files/${PORTNAME}-${PORTVERSION}.patch || { exit 1; }
 
-# Add a pre-install target to get the built library where we expect it.
-# Copy the header files manually
-PREINSTALL = libzip_preinstall
 libzip_preinstall:
 	cp "build/${PORTNAME}-${PORTVERSION}/lib/libzip.a" "build/${PORTNAME}-${PORTVERSION}"
 	mkdir -p inst/include
 	cp "build/${PORTNAME}-${PORTVERSION}/lib/zip.h" inst/include
 	cp "build/${PORTNAME}-${PORTVERSION}/zipconf.h" inst/include
-
-include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/opus/Makefile
+++ b/opus/Makefile
@@ -31,9 +31,8 @@ MAKE_TARGET =       libopus.la
 KOS_DISTFILES =
 
 # Add a pre-install target to get the built library where we expect it.
-PREINSTALL = opus_preinstall
-
-opus_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/.libs/${TARGET} build/${PORTNAME}-${PORTVERSION}
+PREINSTALL =        opus_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+opus_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/.libs/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/opusfile/Makefile
+++ b/opusfile/Makefile
@@ -31,9 +31,8 @@ MAKE_TARGET =       libopusfile.la
 KOS_DISTFILES =
 
 # Add a pre-install target to get the built library where we expect it.
-PREINSTALL = opusfile_preinstall
-
-opusfile_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/.libs/${TARGET} build/${PORTNAME}-${PORTVERSION}
+PREINSTALL =        opusfile_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+opusfile_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/.libs/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/polarssl/Makefile
+++ b/polarssl/Makefile
@@ -6,7 +6,7 @@ MAINTAINER =        Damian Parrino <bucanero@users.noreply.github.com>
 LICENSE =           GPL2
 SHORT_DESC =        A Secure Socket Layer library.
 
-# This port uses CMake
+# This port uses CMake.
 PORT_BUILD =        cmake
 
 # What files we need to download, and where from.
@@ -22,16 +22,17 @@ HDR_DIRECTORY =     include/polarssl
 CMAKE_ARGS =        -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE
 
 # Minor adjustments before building the source code
-PREBUILD = polarssl_prebuild
-polarssl_prebuild:
-	cd "build/${PORTNAME}-${PORTVERSION}" && \
-	patch -p1 < ../../files/${PORTNAME}-${PORTVERSION}.patch || { exit 1; }
+PREBUILD =          polarssl_prebuild
 
 # Add a pre-install target to get the built library where we expect it.
 # This, copied from opus, might be solvable by
 # adding an equivalent to HDR_DIRECTORY for lib
-PREINSTALL = polarssl_preinstall
-polarssl_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/library/${TARGET} build/${PORTNAME}-${PORTVERSION}
+PREINSTALL =        polarssl_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+polarssl_prebuild:
+	cd "build/${PORTNAME}-${PORTVERSION}" && \
+	patch -p1 < ../../files/${PORTNAME}-${PORTVERSION}.patch || { exit 1; }
+
+polarssl_preinstall:
+	cp build/${PORTNAME}-${PORTVERSION}/library/${TARGET} build/${PORTNAME}-${PORTVERSION}

--- a/raylib4dc/Makefile
+++ b/raylib4dc/Makefile
@@ -21,11 +21,11 @@ DISTFILE_DIR =      ${PORTNAME}-${PORTVERSION}/src
 KOS_MAKEFILE =      Makefile
 
 PREINSTALL = raylib_preinstall
+
+include ${KOS_PORTS}/scripts/kos-ports.mk
 raylib_preinstall:
 	@mkdir -p inst/lib inst/include
 	@cp build/${DISTFILE_DIR}/${TARGET} inst/lib
 	@for hdr in ${HDRS}; do \
 		cp build/${DISTFILE_DIR}/$$hdr inst/include; \
 	done
-
-include ${KOS_PORTS}/scripts/kos-ports.mk


### PR DESCRIPTION
Previously, when running `make` in a port's dir, the `all` target is executed, which just prints the following text:

`Please build your port with 'make install clean'.`

This is because `all` is the first target in `scripts/kos-ports.mk`, thus the default target.

However, with #55 and subsequently, several ports added new `PREBUILD` and `PREINSTALL` targets included in the `Makefile` itself before `scripts/kos-ports.mk` gets `include`d. Therefore those targets then become the default, leading to a confusing error message being printed when `make` is executed, e.g.:

```
cp build/libbearssl-1.0.0/build/libbearssl.a build/libbearssl-1.0.0
cp: cannot stat 'build/libbearssl-1.0.0/build/libbearssl.a': No such file or directory
make: *** [Makefile:19: bearssl_preinstall] Error 1
```

This has been fixed by positioning those targets _after_ the `include ${KOS_PORTS}/scripts/kos-ports.mk`.

Additionally, most of the new CMake ports erroneously used the comment `This port uses the autotools scripts that are included with the distfiles.` instead of `This port uses CMake.` This has been fixed, as well as some indenting whitespace/trailing whitespace stuff.