### PR TITLE
Reintroduced SDL changes for new kbd API.

### DIFF
--- a/SDL/files/SDL_dcevents.c
+++ b/SDL/files/SDL_dcevents.c
@@ -25,6 +25,7 @@
     slouken@libsdl.org
 
     Modified by Lawrence Sebald <bluecrab2887@netscape.net>
+    Modified by Falco Girgis <gyrovorbis@gmail.com>
 */
 
 #include "SDL.h"
@@ -33,9 +34,7 @@
 #include "SDL_dcvideo.h"
 #include "SDL_dcevents_c.h"
 
-#include <dc/maple.h>
-#include <dc/maple/mouse.h>
-#include <dc/maple/keyboard.h>
+#include <kos.h>
 
 const static unsigned short sdl_key[]= {
     /*0*/	0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
@@ -101,7 +100,11 @@ static void mouse_update(void) {
 }
 
 static void keyboard_update(void) {
+#if KOS_VERSION_BELOW(2, 1, 1)
     static kbd_state_t old_state;
+#else 
+	static kbd_mods_t old_mods;
+#endif
     kbd_state_t	*state;
     maple_device_t *dev;
     int shiftkeys;
@@ -116,6 +119,7 @@ static void keyboard_update(void) {
     if(!state)
         return;
 
+#if KOS_VERSION_BELOW(2, 1, 1)
     shiftkeys = state->shift_keys ^ old_state.shift_keys;
     for(i = 0; i < sizeof(sdl_shift); ++i) {
         if((shiftkeys >> i) & 1) {
@@ -124,7 +128,7 @@ static void keyboard_update(void) {
                                 SDL_PRESSED : SDL_RELEASED, &keysym);
         }
     }
-
+    
     for(i = 0; i < sizeof(sdl_key); ++i) {
         if(state->matrix[i] != old_state.matrix[i]) {
             int key = sdl_key[i];
@@ -137,7 +141,30 @@ static void keyboard_update(void) {
     }
 
     old_state = *state;
+
+#else /* KOS 2.1.1+ */
+    shiftkeys = state->modifiers.raw ^ old_mods.raw;
+    for(i = 0; i < sizeof(sdl_shift)/sizeof(sdl_shift[0]); ++i) {
+        if((shiftkeys >> i) & 1) {
+            keysym.sym = sdl_shift[i];
+            SDL_PrivateKeyboard(((state->modifiers.raw >> i) & 1) ?
+                                SDL_PRESSED : SDL_RELEASED, &keysym);
+        }
+    }
+
+    for(i = 0; i < sizeof(sdl_key)/sizeof(sdl_key[0]); ++i) {
+        int key = sdl_key[i];
+        keysym.sym = key;
+
+        if(state->key_states[i].value == KEY_STATE_CHANGED_DOWN) {
+            SDL_PrivateKeyboard(SDL_PRESSED, &keysym);
+        } else if(state->key_states[i].value == KEY_STATE_CHANGED_UP) {
+            SDL_PrivateKeyboard(SDL_RELEASED, &keysym);
+        }
+    }
+#endif
 }
+
 
 void DC_PumpEvents(_THIS) {
     keyboard_update();

--- a/SDL/files/SDL_dcevents.c
+++ b/SDL/files/SDL_dcevents.c
@@ -128,7 +128,7 @@ static void keyboard_update(void) {
                                 SDL_PRESSED : SDL_RELEASED, &keysym);
         }
     }
-    
+
     for(i = 0; i < sizeof(sdl_key); ++i) {
         if(state->matrix[i] != old_state.matrix[i]) {
             int key = sdl_key[i];
@@ -142,7 +142,7 @@ static void keyboard_update(void) {
 
     old_state = *state;
 
-#else /* KOS 2.1.1+ */
+#else /* KOS 2.2.0+ */
     shiftkeys = state->modifiers.raw ^ old_mods.raw;
     for(i = 0; i < sizeof(sdl_shift)/sizeof(sdl_shift[0]); ++i) {
         if((shiftkeys >> i) & 1) {
@@ -164,7 +164,6 @@ static void keyboard_update(void) {
     }
 #endif
 }
-
 
 void DC_PumpEvents(_THIS) {
     keyboard_update();

--- a/SDL/files/SDL_dcevents.c
+++ b/SDL/files/SDL_dcevents.c
@@ -100,7 +100,7 @@ static void mouse_update(void) {
 }
 
 static void keyboard_update(void) {
-#if KOS_VERSION_BELOW(2, 1, 1)
+#if KOS_VERSION_BELOW(2, 2, 0)
     static kbd_state_t old_state;
 #else 
 	static kbd_mods_t old_mods;
@@ -119,7 +119,7 @@ static void keyboard_update(void) {
     if(!state)
         return;
 
-#if KOS_VERSION_BELOW(2, 1, 1)
+#if KOS_VERSION_BELOW(2, 2, 0)
     shiftkeys = state->shift_keys ^ old_state.shift_keys;
     for(i = 0; i < sizeof(sdl_shift); ++i) {
         if((shiftkeys >> i) & 1) {


### PR DESCRIPTION
Here's the revived PR for the SDL keyboard changes that are required for the new keyboard API work: https://github.com/KallistiOS/KallistiOS/pull/503. 

~~PLEASE NOTE: The version guards currently assume `KOS_VERSION(2, 1, 1)`. Make sure they are changed to match whichever version this makes it into!~~

Talked to @QuzarDC and ensured it's now targetting KOS 2.2.0!