### PR TITLE
feat: Implement new update system with git hash tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib/*
 examples/*
 inst
 .DS_Store
+*.hash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kos-ports: KallistiOS Package Manager
 
 ## Introduction
+
 **kos-ports** is a package manager and repository of various useful libraries that
 have been ported to the Dreamcast operating system
 [KallistiOS](https://github.com/KallistiOS/KallistiOS). These libraries include
@@ -11,13 +12,16 @@ build on the current version of KallistiOS. Dependency libraries will be fetched
 built automatically, if necessary.
 
 ## Prerequisites
+
 ### KallistiOS
+
 Users must have a [KallistiOS](https://github.com/KallistiOS/KallistiOS) environment
 set up already. This means you must have an SH4 toolchain built and have already
 compiled KallistiOS itself. Before attempting to build a port, make sure you have
 sourced your KallistiOS `environ.sh` file in your current terminal.
 
 ### Environment
+
 1. `curl` or `wget` are required to download packages. `curl` is used by default,
    but `wget` may be set as an alternative in `config.mk`.
 2. GNU make and Bash. Other make tools and shells have not been tested and
@@ -27,6 +31,7 @@ sourced your KallistiOS `environ.sh` file in your current terminal.
    skip validation, you can set this in `config.mk`.
 
 ### Building a port
+
 kos-ports was modelled after the FreeBSD ports collection, so some users may
 be familiar with the usage.
 
@@ -39,10 +44,14 @@ in `kos-ports/lib`. These paths are automatically included in your build flags i
 you are using the KOS Makefile system.
 
 ## Using the ports tree
+
 There are a few available `make` targets that can be used in each port directory:
 
 - **install**: Perform all steps to download, patch, build, and install the port in
                question.
+- **update**: Check if an installed port has updates in its git repository and rebuild
+              if necessary. For ports not yet installed, it will suggest running
+              `make install` instead.
 - **clean**: Clean up any dist files and intermediate build results.
 - **uninstall**: Uninstall the port. This does not make sure dependencies are still
                  fulfilled, so keep that in mind!
@@ -50,14 +59,19 @@ There are a few available `make` targets that can be used in each port directory
                 port in question.
 
 ### Managing all ports
+
 The following helper scripts are provided in the `utils` directory to perform
 the above operations on **all** ports in the tree:
+
 - `build-all.sh` will **install** all ports.
 - `uninstall-all.sh` will **uninstall** all ports.
 - `clean-all.sh` will **clean** all ports.
+- `update-all.sh` will update any of the installed ports if necessary.
 
-#### Lesser used targets (mainly for internal use):
-- **version-check**: Check the version of the port that is currently installed.
+#### Lesser used targets (mainly for internal use)
+
+- **show-deps**: Display all dependencies and sub-dependencies for the port,
+                 along with their installation status.
 - **depends-check**: Check if all dependencies of the port are installed.
 - **abi-check**: Check if the current KOS floating-point ABI is compatible.
 - **fetch**: Download dist files from upstream.
@@ -68,6 +82,7 @@ the above operations on **all** ports in the tree:
 - **clean-build**: Cleans up build files, leaving dist files in place.
 
 ## Porting a new library
+
 Porting a new library is meant to be a relatively simple task. Take a look at
 an existing port, such as `libpng`, to get an idea how the package manager works.
 If you need assistance, feel free to reach out using the usual support channels.

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -40,7 +40,19 @@ else
 endif
 	touch build-stamp
 
-install: setup-check version-check abi-check depends-check force-install
+install: setup-check abi-check depends-check
+	@if [ -f "${KOS_PORTS}/lib/.kos-ports/${PORTNAME}" ] ; then \
+		installed_version=`cat "${KOS_PORTS}/lib/.kos-ports/${PORTNAME}"` ; \
+		if [ "$$installed_version" = "${PORTVERSION}" ] ; then \
+			if [ -f "${KOS_PORTS}/lib/.kos-ports/${PORTNAME}.hash" ] ; then \
+				echo "${PORTNAME} version ${PORTVERSION} is already installed." ; \
+				echo "To force reinstall, run: make uninstall && make install" ; \
+				echo "To check for updates, run: make update" ; \
+				exit 0 ; \
+			fi ; \
+		fi ; \
+	fi ; \
+	$(MAKE) force-install store-hash
 
 force-install: build-stamp $(PREINSTALL)
 	@if [ ! -d "inst" ] ; then \
@@ -103,3 +115,25 @@ force-install: build-stamp $(PREINSTALL)
 
 	@echo "Marking ${PORTNAME} ${PORTVERSION} as installed."
 	@echo "${PORTVERSION}" > "${KOS_PORTS}/lib/.kos-ports/${PORTNAME}"
+
+# Store git hash after successful build
+store-hash:
+	@if [ -d "build/${DISTFILE_DIR}" ] ; then \
+		cd "build/${DISTFILE_DIR}" ; \
+		if [ -n "${GIT_BRANCH}" ] ; then \
+			echo "Checking specified branch: ${GIT_BRANCH}" ; \
+			git checkout ${GIT_BRANCH} > /dev/null 2>&1 ; \
+		else \
+			if git show-ref --verify --quiet refs/heads/main ; then \
+				echo "Using default branch: main" ; \
+				git checkout main > /dev/null 2>&1 ; \
+			elif git show-ref --verify --quiet refs/heads/master ; then \
+				echo "Using default branch: master" ; \
+				git checkout master > /dev/null 2>&1 ; \
+			fi ; \
+		fi ; \
+		current_hash=`git rev-parse HEAD` ; \
+		mkdir -p ${KOS_PORTS}/lib/.kos-ports ; \
+		echo "$$current_hash" > ${KOS_PORTS}/lib/.kos-ports/${PORTNAME}.hash ; \
+		echo "Stored git hash: $$current_hash" ; \
+	fi

--- a/scripts/version.mk
+++ b/scripts/version.mk
@@ -4,21 +4,120 @@
 # Copyright (C) 2015 Lawrence Sebald
 #
 
-version-check:
+# Update target that handles both git and version-based ports
+update:
 	@if [ -f ${KOS_PORTS}/lib/.kos-ports/${PORTNAME} ] ; then \
-		a=`cat ${KOS_PORTS}/lib/.kos-ports/${PORTNAME}` ; \
-		${KOS_PORTS}/scripts/vercmp.sh $$a ${PORTVERSION} ; \
-		res=$$? ; \
-		if [ "$$res" -eq "0" ] ; then \
-			echo "${PORTNAME} is already installed and is latest version. Exiting." ; \
-			exit 1 ; \
-		elif [ "$$res" -eq "1" ] ; then \
-			echo "${PORTNAME} is already installed and is newer than latest version!" ; \
-			echo "Ports collection out of sync. Please update! Exiting." ; \
-			exit 255 ; \
+		if [ -n "${GIT_REPOSITORY}" ] ; then \
+			if [ -f "${KOS_PORTS}/lib/.kos-ports/${PORTNAME}.hash" ] ; then \
+				last_hash=`cat ${KOS_PORTS}/lib/.kos-ports/${PORTNAME}.hash` ; \
+				echo "Last stored hash: $$last_hash" ; \
+				tmp_dir=`mktemp -d` ; \
+				max_retries=3 ; \
+				retry_count=1 ; \
+				while [ $$retry_count -le $$max_retries ] ; do \
+					echo "Attempting to clone repository (attempt $$retry_count of $$max_retries)..." ; \
+					git clone ${GIT_REPOSITORY} $$tmp_dir > /dev/null 2>&1 ; \
+					if [ $$? -eq 0 ] ; then \
+						break ; \
+					fi ; \
+					if [ $$retry_count -lt $$max_retries ] ; then \
+						echo "Clone failed, retrying in 5 seconds..." ; \
+						sleep 5 ; \
+					fi ; \
+					retry_count=$$((retry_count + 1)) ; \
+				done ; \
+				if [ $$retry_count -gt $$max_retries ] ; then \
+					echo "Failed to clone repository after $$max_retries attempts." ; \
+					echo "Please check your network connection and repository URL: ${GIT_REPOSITORY}" ; \
+					rm -rf $$tmp_dir ; \
+					exit 1 ; \
+				fi ; \
+				cd $$tmp_dir ; \
+				if [ -n "${GIT_BRANCH}" ] ; then \
+					echo "Checking specified branch: ${GIT_BRANCH}" ; \
+					git checkout ${GIT_BRANCH} > /dev/null 2>&1 ; \
+				else \
+					if git show-ref --verify --quiet refs/heads/main ; then \
+						echo "Using default branch: main" ; \
+						git checkout main > /dev/null 2>&1 ; \
+					elif git show-ref --verify --quiet refs/heads/master ; then \
+						echo "Using default branch: master" ; \
+						git checkout master > /dev/null 2>&1 ; \
+					else \
+						echo "Error: No default branch (main or master) found in repository" ; \
+						cd - > /dev/null ; \
+						rm -rf $$tmp_dir ; \
+						exit 1 ; \
+					fi ; \
+				fi ; \
+				current_hash=`git rev-parse HEAD` ; \
+				echo "Current repository hash: $$current_hash" ; \
+				cd - > /dev/null ; \
+				rm -rf $$tmp_dir ; \
+				if [ "$$last_hash" = "$$current_hash" ] ; then \
+					echo "${PORTNAME} is up to date with git repository. No changes detected." ; \
+					exit 0 ; \
+				else \
+					echo "${PORTNAME} has new changes in repository. Rebuilding..." ; \
+					cd ${KOS_PORTS} && $(MAKE) -C ${PORTNAME} clean install ; \
+				fi ; \
+			else \
+				echo "${PORTNAME} is installed but no git hash is stored yet." ; \
+				echo "Performing clean reinstall to ensure latest state..." ; \
+				cd ${KOS_PORTS} && $(MAKE) -C ${PORTNAME} uninstall clean install ; \
+			fi ; \
 		else \
-			echo "${PORTNAME} $$a installed. Update to ${PORTVERSION}." ; \
+			installed_version=`cat ${KOS_PORTS}/lib/.kos-ports/${PORTNAME}` ; \
+			${KOS_PORTS}/scripts/vercmp.sh $$installed_version ${PORTVERSION} ; \
+			res=$$? ; \
+			if [ "$$res" -eq "0" ] ; then \
+				echo "${PORTNAME} version $$installed_version is up to date." ; \
+				exit 0 ; \
+			elif [ "$$res" -eq "1" ] ; then \
+				echo "${PORTNAME} version $$installed_version is newer than ports version ${PORTVERSION}!" ; \
+				echo "Ports collection might be out of sync. Please check for updates." ; \
+				exit 1 ; \
+			else \
+				echo "${PORTNAME} version $$installed_version is installed, but version ${PORTVERSION} is available." ; \
+				echo "Performing clean reinstall to update..." ; \
+				cd ${KOS_PORTS} && $(MAKE) -C ${PORTNAME} uninstall clean install ; \
+			fi ; \
 		fi ; \
 	else \
 		echo "${PORTNAME} is not currently installed." ; \
+		echo "Nothing to update. To install this port, run: make clean install" ; \
+		exit 1 ; \
 	fi
+
+# Show dependencies for this port
+show-deps:
+	@if [ -n "${DEPENDENCIES}" ] ; then \
+		echo "Dependencies for ${PORTNAME}:" ; \
+		for _dep in ${DEPENDENCIES}; do \
+			if [ -f "${KOS_PORTS}/lib/.kos-ports/$$_dep" ] ; then \
+				printf "  ✓ %s (installed)\n" "$$_dep" ; \
+			else \
+				printf "  ✗ %s (not installed)\n" "$$_dep" ; \
+			fi ; \
+			if [ -f "${KOS_PORTS}/$$_dep/Makefile" ] ; then \
+				cd "${KOS_PORTS}/$$_dep" && \
+				subdeps=`${MAKE} print-deps 2>/dev/null` ; \
+				if [ -n "$$subdeps" ] ; then \
+					echo "    Sub-dependencies:" ; \
+					for _subdep in $$subdeps; do \
+						if [ -f "${KOS_PORTS}/lib/.kos-ports/$$_subdep" ] ; then \
+							printf "      ✓ %s (installed)\n" "$$_subdep" ; \
+						else \
+							printf "      ✗ %s (not installed)\n" "$$_subdep" ; \
+						fi ; \
+					done ; \
+				fi ; \
+			fi ; \
+		done ; \
+	else \
+		echo "${PORTNAME} has no dependencies beyond the base system." ; \
+	fi
+
+# Helper target to print dependencies
+print-deps:
+	@echo "${DEPENDENCIES}"

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -13,21 +13,14 @@ error_count=0
 for _dir in ${KOS_PORTS}/* ; do
     if [ -d "${_dir}" ] ; then
         if [ -f "${_dir}/Makefile" ] ; then
-            echo "Checking if ${_dir} is installed and up-to-date..."
-            ${KOS_MAKE} -C "${_dir}" version-check > /dev/null 2>&1
+            portname=$(basename "${_dir}")
+            echo "Building ${_dir}..."
+            ${KOS_MAKE} -C "${_dir}" clean install
             rv=$?
-            if [ "$rv" -eq 0 ] ; then
-                echo "Building ${_dir}..."
-                ${KOS_MAKE} -C "${_dir}" install clean
-                rv=$?
-                echo $rv
-                if [ "$rv" -ne 0 ] ; then
-                    echo "Error building ${_dir}."
-                    errors="${errors}${_dir}: Build failed with return code ${rv}\n"
-                    error_count=$((error_count + 1))
-                fi
-            else
-                echo "${_dir} is already installed and up-to-date. Skipping."
+            if [ "$rv" -ne 0 ] ; then
+                echo "Error building ${_dir}."
+                errors="${errors}${_dir}: Build failed with return code ${rv}\n"
+                error_count=$((error_count + 1))
             fi
         fi
     fi

--- a/utils/update-all.sh
+++ b/utils/update-all.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# kos-ports ##version##
+#
+# utils/update-all.sh
+# Copyright (C) 2025 Panos Georgiadis
+#
+
+cd ${KOS_PORTS}
+errors=""
+error_count=0
+update_count=0
+uptodate_count=0
+skip_count=0
+updated_ports=""
+failed_ports=""
+
+for _dir in ${KOS_PORTS}/* ; do
+    if [ -d "${_dir}" ] ; then
+        if [ -f "${_dir}/Makefile" ] ; then
+            portname=$(basename "${_dir}")
+            if [ -f "${KOS_PORTS}/lib/.kos-ports/${portname}" ] ; then
+                echo "Checking updates for ${_dir}..."
+                ${KOS_MAKE} -C "${_dir}" update > update.log 2>&1
+                rv=$?
+                cat update.log
+                if [ "$rv" -eq 0 ] ; then
+                    # Check if the port was actually updated or just checked
+                    if grep -q "is up to date" update.log || \
+                       grep -q "No changes detected" update.log || \
+                       grep -q "version .* is up to date" update.log || \
+                       grep -q "is already installed" update.log ; then
+                        uptodate_count=$((uptodate_count + 1))
+                    else
+                        # Only count as updated if we see actual update messages
+                        if grep -q "has new changes in repository" update.log || \
+                           grep -q "version .* is available" update.log ; then
+                            update_count=$((update_count + 1))
+                            updated_ports="${updated_ports}${portname}\n"
+                        else
+                            uptodate_count=$((uptodate_count + 1))
+                        fi
+                    fi
+                else
+                    if [ "$rv" -eq 1 ] && [ -f "${KOS_PORTS}/lib/.kos-ports/${portname}" ] ; then
+                        # Exit code 1 with installed port means "no updates available"
+                        uptodate_count=$((uptodate_count + 1))
+                        echo "${_dir} is up to date."
+                    else
+                        echo "Error updating ${_dir}."
+                        errors="${errors}${_dir}: Update failed with return code ${rv}\n"
+                        error_count=$((error_count + 1))
+                        failed_ports="${failed_ports}${portname}\n"
+                    fi
+                fi
+                rm -f update.log
+            else
+                echo "Skipping ${_dir} (not installed)"
+                skip_count=$((skip_count + 1))
+            fi
+        fi
+    fi
+done
+
+echo "\n-------------------------------------------------"
+echo "Status Summary:"
+if [ "$update_count" -gt 0 ] ; then
+    echo "✓ Updated: $update_count port(s)"
+    echo "  Updated ports:"
+    printf "$updated_ports" | while read port; do
+        echo "    - $port"
+    done
+fi
+if [ "$uptodate_count" -gt 0 ] ; then
+    echo "✓ Up to date: $uptodate_count port(s)"
+fi
+if [ "$skip_count" -gt 0 ] ; then
+    echo "- Skipped: $skip_count port(s) (not installed)"
+fi
+if [ -n "$errors" ]; then
+    echo "✗ Failed: $error_count port(s):"
+    printf "$failed_ports" | while read port; do
+        echo "    - $port"
+    done
+    echo "$errors"
+fi
+exit $error_count 


### PR DESCRIPTION
This commit introduces a new update system that uses git hashes to track changes in git-based ports and version numbers for non-git ports. Key changes:

- Add git hash tracking for git-based ports
- Replace version-check with new update target that handles both git and version-based ports
- Add update-all.sh utility script for managing all ports
- Update build-all.sh to use clean install instead of version-check
- Add *.hash to .gitignore to prevent tracking local state
- Update documentation to reflect new update system and remove version-check

The new system provides better tracking of git-based ports and clearer status reports during updates. It also maintains backward compatibility with version-based ports while adding more robust update detection for git repositories.