### PR TITLE
Update FreeType to version 2.13.3

### DIFF
--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          freetype
-PORTVERSION =       2.13.2
+PORTVERSION =       2.13.3
 
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           FreeType License or GPLv2 (see docs/LICENSE.TXT in the source distribution)
@@ -17,8 +17,8 @@ DEPENDENCIES =      libbz2 zlib libpng
 
 # What files we need to download, and where from.
 DOWNLOAD_SITES =    https://download.savannah.gnu.org/releases/freetype/ \
-                    https://sourceforge.net/projects/freetype/files/freetype2/2.13.2/
-DOWNLOAD_FILES =    freetype-2.13.2.tar.gz
+                    https://sourceforge.net/projects/freetype/files/freetype2/2.13.3/
+DOWNLOAD_FILES =    freetype-2.13.3.tar.gz
 
 TARGET =            libfreetype.a
 HDR_FULLDIR =       freetype2

--- a/freetype/distinfo
+++ b/freetype/distinfo
@@ -1,2 +1,2 @@
-SHA256 (freetype-2.13.2.tar.gz) = 1ac27e16c134a7f2ccea177faba19801131116fd682efc1f5737037c5db224b5
-SIZE (freetype-2.13.2.tar.gz) = 3875020
+SHA256 (freetype-2.13.3.tar.gz) = 5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747
+SIZE (freetype-2.13.3.tar.gz) = 4063324


### PR DESCRIPTION
bump to version 2.13.3

Release notes:

> The B/W rasterizer has become much faster; besides that, it is a maintenance release.

Full changelog:
> 
> CHANGES BETWEEN 2.13.2 and 2.13.3 (2024-Aug-11)
> 
>   **I. IMPORTANT CHANGES**
> 
>   - Some  fields  in  the  `FT_Outline` structure  have been   changed
>     from signed  to unsigned type,  which  better reflects  the actual
>     usage.   It  is  also  an  additional  means  to  protect  against
>     malformed input.
> 
> 
>   **II. IMPORTANT BUG FIXES**
> 
>   - Rare double-free crashes in the cache subsystem have been fixed.
> 
>   - Excessive stack allocation in the autohinter has been fixed.
> 
> 
>   **III. MISCELLANEOUS**
> 
>   - The B/W  rasterizer has  received a major  upkeep that  results in
>     large performance improvements.  The rendering speed has increased
>     and even doubled for very complex glyphs.
> 
>   - If the new configuration option `TT_CONFIG_OPTION_GPOS_KERNING` is
>     defined,  `FT_Get_Kerning`  understands rudimentary  GPOS  kerning
>     (for TrueType fonts  only).  This is not enabled  by default since
>     its usage  is very  limited, mainly  for legacy  applications that
>     have to support TrueType fonts automatically converted from 'kern'
>     tables to GPOS kerning.  If you need proper (GPOS) kerning support
>     please use a higher-level library like HarfBuzz.
> 
>     Code contributed by David Saltzman.
> 
>   - The internal structures  `PS_DesignMap` and `PS_Blend` related  to
>     parsing of old Multiple Masters fonts  have been removed  from the
>     public header file `t1tables.h`.
>   