### PR TITLE
Add missing include to kos_zlib.

### DIFF
--- a/zlib/files/KOSMakefile.mk
+++ b/zlib/files/KOSMakefile.mk
@@ -2,6 +2,6 @@ TARGET = libz.a
 OBJS = adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o \
        infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o kos_zlib.o
 
-KOS_CFLAGS += -I.
+KOS_CFLAGS += -I. -DHAVE_UNISTD_H -DHAVE_STDARG_H
 
 include ${KOS_PORTS}/scripts/lib.mk

--- a/zlib/files/kos_zlib.c
+++ b/zlib/files/kos_zlib.c
@@ -1,5 +1,6 @@
 #include <zlib.h>
 #include <stdio.h>
+#include <kos/fs.h>
 
 /* Macros taken from gzip source to read header values */
 static int gzmagic[2] = {0x1f, 0x8b};


### PR DESCRIPTION
zlib was implicitly getting fs_ calls from stdio before [KOS#995](https://github.com/KallistiOS/KallistiOS/pull/995). This makes the inclusion explicit. A second commit updated the makefile to ensure other includes were being appropriately accounted for.