### PR TITLE
Updated Lua to version 5.4.8.

### DIFF
--- a/lua/Makefile
+++ b/lua/Makefile
@@ -1,10 +1,10 @@
 # Port Metadata
 PORTNAME =          lua
-PORTVERSION =       5.4.7
+PORTVERSION =       5.4.8
 
 MAINTAINER =        Falco Girgis (GyroVorbis)
 LICENSE =           MIT
-SHORT_DESC =        Embeddable scripting language
+SHORT_DESC =        Lightweight, embeddable, extensible scripting language
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/lua/distinfo
+++ b/lua/distinfo
@@ -1,2 +1,2 @@
-SHA256 (lua-5.4.7.tar.gz) = 9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
-SIZE (lua-5.4.7.tar.gz) = 374097
+SHA256 (lua-5.4.8.tar.gz) = 4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
+SIZE (lua-5.4.8.tar.gz) = 374332


### PR DESCRIPTION
- Bugfix version, although some of the bugs seem like a pretty big deal
  (use-after-free, issues with raising errors in certain contexts, coroutines issue).
- Added better description for Lua KOS-port.