### PR TITLE
`mruby`: remove hardcoded compiler options, improve DreamSDK detection, bug fix in header update

### DIFF
--- a/mruby/Makefile
+++ b/mruby/Makefile
@@ -12,7 +12,7 @@ DEPENDENCIES =
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/mruby/mruby.git
 GIT_BRANCH =        master
-GIT_TAG =           3.3.0
+GIT_TAG =           ${PORTVERSION}
 
 TARGET =            libmruby.a
 HDR_DIRECTORY =     build/$(KOS_ARCH)/include


### PR DESCRIPTION
This PR updates mruby:
- Removing hard-coded compiler options (e.g., `sh-elf-gcc`): calling KallistiOS wrappers (e.g., `kos-cc`, ...)
- Better detection of DreamSDK: handle both `ruby`/`rake` from Windows (i.e., from [RubyInstaller](https://rubyinstaller.org/)) and from [MSYS2](https://www.msys2.org/)
- Fix an issue while installing headers: sometimes, the includes were incorrectly modified to `mruby/mruby/mruby/<file.h>`. This is now fixed to update as `mruby/mruby/<file.h>`.

This PR fixes: https://github.com/KallistiOS/kos-ports/issues/113
See: https://github.com/mruby/mruby/pull/6600