### PR TITLE
build.mk script to use kos-cmake wrapper.

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -28,8 +28,7 @@ else ifeq ($(PORT_BUILD), cmake)
 		p=.. ; \
 	fi ; \
 	kos-cmake -DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
-		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib \
-		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF $$p ${CMAKE_ARGS} ; \
+		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib $$p ${CMAKE_ARGS} ; \
 	$(MAKE) ${MAKE_TARGET} ;
 else
 	@if [ -z "${DISTFILE_DIR}" ] ; then \

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -27,9 +27,9 @@ else ifeq ($(PORT_BUILD), cmake)
 		mkdir build ; cd build ; \
 		p=.. ; \
 	fi ; \
-	cmake -DCMAKE_TOOLCHAIN_FILE=${KOS_CMAKE_TOOLCHAIN} \
-		-DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
-		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib $$p ${CMAKE_ARGS} ; \
+	kos-cmake -DCMAKE_INSTALL_INCLUDEDIR=${KOS_PORTS}/${PORTNAME}/inst/include \
+		-DCMAKE_INSTALL_LIBDIR=${KOS_PORTS}/${PORTNAME}/inst/lib \
+		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF $$p ${CMAKE_ARGS} ; \
 	$(MAKE) ${MAKE_TARGET} ;
 else
 	@if [ -z "${DISTFILE_DIR}" ] ; then \


### PR DESCRIPTION
The build system for kos-ports currently raw-dogs "cmake" as the command to build a CMakeLists.txt file, as opposed to our preferred "kos-cmake" wrapper file.

In addition to this requiring us to manually pass the toolchain argument for each invocation, it also means that should kos-cmake need to change in the future, the changes would not permeate out.

~~I just made a bugfix for DreamSDK which forces cmake to use the "Unix Makefiles" generator by explicitly passing it to cmake as part of the kos-cmake wrapper. This is required to ensure that CMake's top generator choice on Windows, freaking Visual Studio, does not get used when trying to build kos-ports.~~