### PR TITLE
CI: Automatically sync to SourceForge

### DIFF
--- a/.github/workflows/sourceforge.yml
+++ b/.github/workflows/sourceforge.yml
@@ -1,0 +1,27 @@
+name: Sourceforge sync
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    if: github.repository == 'KallistiOS/kos-ports'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: setup-ssh
+      run: |
+        install -m 600 -D /dev/null ~/.ssh/id_ed25519
+        echo "${{ secrets.SF_MIRROR_KEY }}" > ~/.ssh/id_ed25519
+        ssh-keyscan -H git.code.sf.net > ~/.ssh/known_hosts
+
+    - name: sourceforge-sync
+      run: |
+        git remote add sourceforge ssh://kosmirror@git.code.sf.net/p/cadcdev/kos-ports
+        git push sourceforge master


### PR DESCRIPTION
Add a Github action which triggers every time the master branch is bumped, that will sync the old SourceForge repo.

@ljsebald you might have to add the `SF_MIRROR_KEY` secret for the kos-ports repo (like you previously did for the KallistiOS repo); I suspect it should have the same value as the one you set up for the KallistiOS repo since on the SourceForge side both repos are in the "cadcdev" organization.