### PR TITLE
Added missing `pkg-descr` files.

### DIFF
--- a/curl/pkg-descr
+++ b/curl/pkg-descr
@@ -1,0 +1,7 @@
+curl is used in command lines or scripts to transfer data. curl is also libcurl,
+used in cars, television sets, routers, printers, audio equipment, mobile
+phones, tablets, medical devices, settop boxes, computer games, media players
+and is the Internet transfer engine for countless software applications in over
+twenty billion installations.
+
+URL: https://curl.se/

--- a/libzip/pkg-descr
+++ b/libzip/pkg-descr
@@ -1,0 +1,9 @@
+libzip is a cross-platform ZIP library developed since 2005 that runs on Linux,
+macOS, Windows, and other operating systems. It prioritizes API stability, data
+integrity, and efficiency while supporting modern ZIP features including Zip64
+for large archives, multiple compression algorithms (Deflate, bzip2, LZMA,
+zstd), and various encryption methods. The library can read from files or memory
+buffers, allows reverting changes, and uses a BSD license making it suitable for
+commercial use.
+
+URL: https://libzip.org/

--- a/polarssl/pkg-descr
+++ b/polarssl/pkg-descr
@@ -1,0 +1,6 @@
+mbed TLS is a cryptographic library designed to easily integrate SSL/TLS and
+cryptographic capabilities into embedded and other products with minimal code
+overhead. Originally developed as PolarSSL, it was acquired by ARM and rebranded
+as mbed TLS, making it part of ARM's official product suite.
+
+URL: https://www.trustedfirmware.org/projects/mbed-tls/


### PR DESCRIPTION
This will also allow DreamSDK Manager to correctly detect these ports.