### PR TITLE
Allow `KOS_MAKEFILE` to be passed `MAKE_TARGET` and update bearssl to do so. 

### DIFF
--- a/libbearssl/Makefile
+++ b/libbearssl/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          libbearssl
-PORTVERSION =       1.0.0
+PORTVERSION =       1.0.1
 
 MAINTAINER =        Donald Haase
 LICENSE =           MIT License
@@ -16,7 +16,7 @@ HDR_DIRECTORY =     inc
 # Add a pre-install target to get the built library where we expect it.
 PREINSTALL = bearssl_preinstall
 
-MAKE_TARGET =       all install
+MAKE_TARGET =       lib
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
 bearssl_preinstall:

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -32,9 +32,9 @@ else ifeq ($(PORT_BUILD), cmake)
 	cmake --build . -t $(or ${MAKE_TARGET},all) ;
 else
 	@if [ -z "${DISTFILE_DIR}" ] ; then \
-		$(MAKE) -C build/${PORTNAME}-${PORTVERSION} -f ${KOS_MAKEFILE} ; \
+		$(MAKE) -C build/${PORTNAME}-${PORTVERSION} -f ${KOS_MAKEFILE} ${MAKE_TARGET} ; \
 	else \
-		$(MAKE) -C build/${DISTFILE_DIR} -f ${KOS_MAKEFILE} ; \
+		$(MAKE) -C build/${DISTFILE_DIR} -f ${KOS_MAKEFILE} ${MAKE_TARGET} ; \
 	fi
 endif
 	touch build-stamp


### PR DESCRIPTION
We allow `MAKE_TARGET` to be passed to cmake or autotools so there's no reason to keep that away from makefile. In this case, it can be used for bearssl, which otherwise wants to create a tool and some test programs that we aren't keeping anyways (and have issues building via DreamSDK).