### PR TITLE
libmp3: Force building against `c17`

### DIFF
--- a/libmp3/files/KOSMakefile.mk
+++ b/libmp3/files/KOSMakefile.mk
@@ -1,6 +1,6 @@
 TARGET = libmp3.a
 SUBDIRS = xingmp3 libmp3
 LIB_OBJS = build/*.o
-KOS_CFLAGS += -Iinclude
+KOS_CFLAGS += -Iinclude -std=c17
 
 include ${KOS_PORTS}/scripts/lib.mk


### PR DESCRIPTION
Newer versions of gcc (15+) default to the `c23`
which libmp3 would need quite a bit of work
to adapt to. For now, forcing it to build
with `-std=c17` to ensure it can build at all.

Closes #115 