### PR TITLE
Allow for GLdc to build without samples or tests

### DIFF
--- a/libGL/Makefile
+++ b/libGL/Makefile
@@ -17,10 +17,12 @@ EXAMPLES_DIR =      samples
 
 # -DCMAKE_BUILD_TYPE=Release forces GLdc to build with upstream's release optimization
 # flags. Remove this argument to create a build without overriding $KOS_CFLAGS.
+# Add -DBUILD_SAMPLES=OFF and/or -DBUILD_TESTS=OFF to speed up compilation by skipping
+# the compilation of GLdc's samples and tests.
 CMAKE_ARGS =        -DCMAKE_BUILD_TYPE=Release
 
 PREINSTALL =        move_samples
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
 move_samples:
-	mv build/${PORTNAME}-${PORTVERSION}/*.elf build/${PORTNAME}-${PORTVERSION}/samples
+	@mv build/${PORTNAME}-${PORTVERSION}/*.elf build/${PORTNAME}-${PORTVERSION}/samples 2>/dev/null || true


### PR DESCRIPTION
GLdc is getting an upstream PR from freakdave that will allow for disabling building tests/samples. This drops the GLdc compile time from `1m 19s` to `4s` on my Ryzen 5950X machine. Unfortunately this makes our Makefile error out on the `move_samples` target, so this PR adjusts things so it neither stops the Makefile nor prints an error to console.