### PR TITLE
Add arch checking support to kos-ports scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,19 @@
 
 ## Introduction
 **kos-ports** is a package manager and repository of various useful libraries that
-have been ported to the Dreamcast operating system
-[KallistiOS](https://github.com/KallistiOS/KallistiOS). These libraries include
-common audiovisual formats (jpg, png, mp3, ogg, mpeg), compression formats (libbz2,
-zlib), scripting languages (Lua, Tcl, MicroPython), gaming APIs (OpenGL, OpenAL,
-SDL), and more.  Each port is meant to be as self-contained as possible and should
-build on the current version of KallistiOS. Dependency libraries will be fetched and
-built automatically, if necessary.
+have been ported to [KallistiOS](https://github.com/KallistiOS/KallistiOS). These
+libraries include common audiovisual formats (jpg, png, mp3, ogg, mpeg), compression
+formats (libbz2, zlib), scripting languages (Lua, Tcl, MicroPython), gaming APIs
+(OpenGL, OpenAL, SDL), and more.  Each port is meant to be as self-contained as
+possible and should build on the current version of KallistiOS. Dependency libraries
+will be fetched and built automatically, if necessary.
 
 ## Prerequisites
 ### KallistiOS
 Users must have a [KallistiOS](https://github.com/KallistiOS/KallistiOS) environment
-set up already. This means you must have an SH4 toolchain built and have already
-compiled KallistiOS itself. Before attempting to build a port, make sure you have
-sourced your KallistiOS `environ.sh` file in your current terminal.
+set up already. This means you must have a toolchain built for your current arch and
+have already compiled KallistiOS itself. Before attempting to build a port, make
+sure you have sourced your KallistiOS `environ.sh` file in your current terminal.
 
 ### Environment
 1. `curl` or `wget` are required to download packages. `curl` is used by default,
@@ -59,6 +58,7 @@ the above operations on **all** ports in the tree:
 #### Lesser used targets (mainly for internal use):
 - **version-check**: Check the version of the port that is currently installed.
 - **depends-check**: Check if all dependencies of the port are installed.
+- **arch-check**: Check if the currently selected arch is compatible.
 - **abi-check**: Check if the current KOS floating-point ABI is compatible.
 - **fetch**: Download dist files from upstream.
 - **validate-dist**: Check downloaded distfiles for validity, if enabled.

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.2.15
 MAINTAINER =        Nobody
 LICENSE =           LGPLv2.1
 SHORT_DESC =        Simple Directmedia Library
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/SDL_ttf/Makefile
+++ b/SDL_ttf/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.2
 MAINTAINER =        Donald Haase
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib
 SHORT_DESC =        SDL TrueType font library
+ARCHS_SUPPORTED =   dreamcast
 
 # This port could use autotools, but it tries to build the glfont example which uses
 # functionality currently unsupported by gldc..

--- a/cglm/Makefile
+++ b/cglm/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Donald Haase
 LICENSE =           MIT
 SHORT_DESC =        Highly optimized 2D|3D math library, also known as OpenGL Mathematics (glm) for `C`
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/config.mk
+++ b/config.mk
@@ -15,6 +15,11 @@ UNPACK_CMD = tar xf
 # recursively.
 BUILD_DEPENDS = true
 
+# Select whether or not to check if a port supports the currently selected arch.
+# If not supported, it will be skipped. If check is disabled, then the port may
+# fail to build for an unsupported arch.
+CHECK_ARCH = true
+
 # Select whether or not to check if a port is compatible with KOS's current
 # floating-point precision ABI setting (KOS_SH4_PRECISION) before building.
 CHECK_PRECISION = true

--- a/curl/Makefile
+++ b/curl/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       7.64.1
 MAINTAINER =        Damian Parrino <bucanero@users.noreply.github.com>
 LICENSE =           custom
 SHORT_DESC =        A library for transferring data with URL syntax.
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/expat/Makefile
+++ b/expat/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.5.0
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           MIT (see COPYING in the source distribution)
 SHORT_DESC =        A C library for parsing XML
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.13.3
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           FreeType License or GPLv2 (see docs/LICENSE.TXT in the source distribution)
 SHORT_DESC =        Freely available software library to render fonts of various types.
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/libADX/Makefile
+++ b/libADX/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.1
 MAINTAINER =        SiZiOUS <sizious@gmail.com>
 LICENSE =           BSD 2-Clause License
 SHORT_DESC =        Library for decoding ADX audio files
+ARCHS_SUPPORTED =   dreamcast
 
 KOS_MAKEFILE =      Makefile
 

--- a/libAL/Makefile
+++ b/libAL/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Luke Benstead <kazade@gmail.com>
 LICENSE =           MIT License
 SHORT_DESC =        OpenAL implementation for KOS
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libGL/Makefile
+++ b/libGL/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.1.0
 MAINTAINER =        Luke Benstead <kazade@gmail.com>
 LICENSE =           2-clause BSD (see LICENSE in the source distribution)
 SHORT_DESC =        GLdc, an OpenGL (tm) like graphics library for KOS
+ARCHS_SUPPORTED =   dreamcast
 
 PORT_BUILD =        cmake
 

--- a/libKGL/Makefile
+++ b/libKGL/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        KallistiGL, deprecated OpenGL (tm) like graphics library for KOS
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libbearssl/Makefile
+++ b/libbearssl/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.1
 MAINTAINER =        Donald Haase
 LICENSE =           MIT License
 SHORT_DESC =        BearSSL is an implementation of the SSL/TLS protocol (RFC 5246) written in C.
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 KOS_MAKEFILE = Makefile
 

--- a/libbz2/Makefile
+++ b/libbz2/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.8
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           BSD-like (see LICENSE in the source distribution)
 SHORT_DESC =        Block-sorting compression library
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libchipmunk/Makefile
+++ b/libchipmunk/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       7.0.3.1
 MAINTAINER =        Donald Haase
 LICENSE =           MIT
 SHORT_DESC =        A fast and lightweight 2D game physics library.
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/libcmark/Makefile
+++ b/libcmark/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       0.31.0
 MAINTAINER =        Donald Haase
 LICENSE =           Custom (see the file COPYING provided with headers or at https://github.com/commonmark/cmark/blob/master/COPYING)
 SHORT_DESC =        CommonMark parsing and rendering library and program in C
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/libconio/Makefile
+++ b/libconio/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Console-like I/O library
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libdcplib/Makefile
+++ b/libdcplib/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           LGPLv2 (with embedded system exemption)
 SHORT_DESC =        A portable game programming library
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libfastmem/Makefile
+++ b/libfastmem/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        SiZiOUS <sizious@gmail.com>
 LICENSE =           LGPLv2.1
 SHORT_DESC =        Very optimized set of memory manipulation functions
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      
 

--- a/libimageload/Makefile
+++ b/libimageload/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Library for decoding BMP, JPEG, and PCX images
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libjpeg
 

--- a/libjimtcl/Makefile
+++ b/libjimtcl/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Spencer (@spencerelliott)
 LICENSE =           FreeBSD
 SHORT_DESC =        An open-source, small footprint implementation of Tcl
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/msteveb/jimtcl.git

--- a/libjpeg/Makefile
+++ b/libjpeg/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       9.5
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           IJG license (see README in the source distribution!)
 SHORT_DESC =        Freely available lossy image compression library (with KOS additions)
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libkmg/Makefile
+++ b/libkmg/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Library for decoding KMG images
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libkosh/Makefile
+++ b/libkosh/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        The KallistiOS shell (library)
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libconio
 

--- a/libmodplug/Makefile
+++ b/libmodplug/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       0.7
 MAINTAINER =        Nobody
 LICENSE =           Public Domain
 SHORT_DESC =        A library for MOD-like tracker music formats
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libmp3/Makefile
+++ b/libmp3/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           GPLv2+ (XingMP3) and KOS License (KOS Glue)
 SHORT_DESC =        Library for decoding and streaming MP3 audio
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libmpeg/Makefile
+++ b/libmpeg/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Andy Barajas
 LICENSE =           MIT
 SHORT_DESC =        Library for decoding MPEG1 Video, MP2 Audio using pl_mpeg
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libogg/Makefile
+++ b/libogg/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.3.5
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Multimedia container format access library
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/liboggvorbisplay/Makefile
+++ b/liboggvorbisplay/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           KOS License
 SHORT_DESC =        Ogg Vorbis audio streaming library
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libvorbis
 

--- a/libopusplay/Makefile
+++ b/libopusplay/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.1.0
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           KOS License
 SHORT_DESC =        Opus audio playback library
+ARCHS_SUPPORTED =   dreamcast
 
 # Requires opusfile (which will pull in opus and libogg)
 DEPENDENCIES =      opusfile

--- a/libparallax/Makefile
+++ b/libparallax/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Simple (mostly 2D) game API library
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libpng libjpeg libkmg
 

--- a/libpcx/Makefile
+++ b/libpcx/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Library for decoding PCX images
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libpng/Makefile
+++ b/libpng/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.6.37
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib
 SHORT_DESC =        Freely available lossless image compression library (with KOS additions)
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      zlib
 

--- a/libsmb2/Makefile
+++ b/libsmb2/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       6.2
 MAINTAINER =        Ronnie Sahlberg
 LICENSE =           LGPLv2.1
 SHORT_DESC =        SMB2/3 userspace client
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        cmake

--- a/libtga/Makefile
+++ b/libtga/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        Library for decoding TGA images
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libtremor/Makefile
+++ b/libtremor/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       19480
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Vorbis audio decoder library (integer version)
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libtsunami/Makefile
+++ b/libtsunami/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       2.0.0
 MAINTAINER =        Nobody
 LICENSE =           KOS License
 SHORT_DESC =        C++ "scene graph" wrapper around libparallax
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libparallax
 

--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Donald Haase
 LICENSE =           MIT-0
 SHORT_DESC =        An e-mail address validation library.
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/libvorbis/Makefile
+++ b/libvorbis/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.3.7
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Vorbis audio codec library (floating-point version)
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libogg
 

--- a/libwav/Makefile
+++ b/libwav/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Andy Barajas
 LICENSE =           Public Domain
 SHORT_DESC =        Library for decoding WAV file headers 
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/libyaml/Makefile
+++ b/libyaml/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       0.2.5
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           MIT (see License in the source distribution)
 SHORT_DESC =        A C library for parsing and emitting YAML
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/libzip/Makefile
+++ b/libzip/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.1
 MAINTAINER =        Damian Parrino <bucanero@users.noreply.github.com>
 LICENSE =           3-clause BSD license
 SHORT_DESC =        libzip is a C library for reading, creating, and modifying zip archives.
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/lua/Makefile
+++ b/lua/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       5.5.0
 MAINTAINER =        Falco Girgis (GyroVorbis)
 LICENSE =           MIT
 SHORT_DESC =        Lightweight, embeddable, extensible scripting language
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/micropython/Makefile
+++ b/micropython/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.26.0
 MAINTAINER =        Aaron Glazer <aaronglazer@google.com>
 LICENSE =           MIT
 SHORT_DESC =        A lean and efficient Python implementation
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 DEPENDENCIES =
 

--- a/mruby/Makefile
+++ b/mruby/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       3.3.0
 MAINTAINER =        SiZiOUS <sizious@gmail.com>
 LICENSE =           MIT
 SHORT_DESC =        Lightweight Ruby
+ARCHS_SUPPORTED =   dreamcast
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/opus/Makefile
+++ b/opus/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.3.1
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Opus audio codec library
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/opusfile/Makefile
+++ b/opusfile/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       0.11
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           3-clause BSD (see COPYING in the source distribution)
 SHORT_DESC =        Opus audio codec library high-level file access library
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses the autotools scripts that are included with the distfiles.
 PORT_BUILD =        autotools

--- a/polarssl/Makefile
+++ b/polarssl/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.3.9
 MAINTAINER =        Damian Parrino <bucanero@users.noreply.github.com>
 LICENSE =           GPL2
 SHORT_DESC =        A Secure Socket Layer library.
+ARCHS_SUPPORTED =   dreamcast
 
 # This port uses CMake.
 PORT_BUILD =        cmake

--- a/raylib4dc/Makefile
+++ b/raylib4dc/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       5.5.0
 MAINTAINER =        Andress Barajas
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib
 SHORT_DESC =        raylib is a simple and easy-to-use library to enjoy videogames programming.
+ARCHS_SUPPORTED =   dreamcast
 
 DEPENDENCIES =      libGL
 NOCOPY_TARGET =     1

--- a/scripts/arch.mk
+++ b/scripts/arch.mk
@@ -1,0 +1,28 @@
+# kos-ports ##version##
+#
+# scripts/arch.mk
+# Copyright (C) 2026 Eric Fradella
+#
+
+ARCHS_SUPPORTED ?= any
+
+arch-check:
+ifeq (${CHECK_ARCH},true)
+    ifeq (${ARCHS_SUPPORTED},any)
+		@echo "${PORTNAME} supports any arch."
+    else
+		@case " $(ARCHS_SUPPORTED) " in *" $(KOS_ARCH) "*) \
+			echo "${PORTNAME} supports the ${KOS_ARCH} arch."; \
+			;; \
+		*) \
+			echo "${PORTNAME} does not support the ${KOS_ARCH} arch. Quitting."; \
+			exit 1; \
+			;; \
+		esac
+    endif
+else ifeq (${CHECK_ARCH},false)
+	@echo "CHECK_ARCH is disabled in config.mk. Skipping arch support check."
+else
+	@echo "CHECK_ARCH is not set in config.mk. Please correct your configuration."
+	exit 1
+endif

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -39,7 +39,7 @@ else
 endif
 	touch build-stamp
 
-install: setup-check version-check abi-check depends-check force-install
+install: setup-check version-check arch-check abi-check depends-check force-install
 
 force-install: build-stamp $(PREINSTALL)
 	@if [ ! -d "inst" ] ; then \

--- a/scripts/kos-ports.mk
+++ b/scripts/kos-ports.mk
@@ -17,6 +17,7 @@ include ${KOS_PORTS}/scripts/unpack.mk
 include ${KOS_PORTS}/scripts/clean.mk
 include ${KOS_PORTS}/scripts/build.mk
 include ${KOS_PORTS}/scripts/version.mk
+include ${KOS_PORTS}/scripts/arch.mk
 include ${KOS_PORTS}/scripts/precision.mk
 include ${KOS_PORTS}/scripts/depends.mk
 include ${KOS_PORTS}/scripts/uninstall.mk

--- a/sh4zam/Makefile
+++ b/sh4zam/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.0.0
 MAINTAINER =        Falco Girgis <gyrovorbis@gmail.com>
 LICENSE =           MIT
 SHORT_DESC =        Hardware accelerated math and linear algebra library for the SH4.
+ARCHS_SUPPORTED =   dreamcast
 
 PORT_BUILD =        cmake
 

--- a/stb_image/Makefile
+++ b/stb_image/Makefile
@@ -5,6 +5,7 @@ PORTVERSION = 2.29
 MAINTAINER  = Jason Rost (OniEnzeru)
 LICENSE     = Public Domain
 SHORT_DESC  = Single header library for image loading supporting many common formats.
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # No dependencies beyond the base system.
 DEPENDENCIES =

--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -5,6 +5,7 @@ PORTVERSION =       1.3.1
 MAINTAINER =        Lawrence Sebald <ljsebald@users.sourceforge.net>
 LICENSE =           zlib License - http://opensource.org/licenses/Zlib
 SHORT_DESC =        Lossless data compression library
+ARCHS_SUPPORTED =   dreamcast gamecube
 
 # No dependencies beyond the base system.
 DEPENDENCIES =


### PR DESCRIPTION
Similar to #90, but this PR adds a check to gate particular ports to supported archs.

- If a port doesn't specify `ARCHS_SUPPORTED`, then it's assumed that it is `any`.
- All existing ports are changed to specify `dreamcast` or `dreamcast gamecube`.
- Ports that do not build, do not make sense for GameCube support, or I had suspicion wouldn't actually work despite building were left without `gamecube`.
- Ports that do include `gamecube` were all verified to build properly and can be reasonably assumed to work, but were not actually all tested.