### PR TITLE
Fixed libvldmail build.

### DIFF
--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -13,9 +13,11 @@ PORT_BUILD =        cmake
 GIT_REPOSITORY =    https://github.com/dertuxmalwieder/libvldmail.git
 TARGET =            libvldmail.a
 INSTALLED_HDRS =    src/vldmail.h
+NOCOPY_TARGET =     true
 
 #Passing this causes the test to be built as a .elf in the build dir.
 #It doesn't quite match the current scheme we have for 'examples'
 CMAKE_ARGS =        -DBUILD_THE_TEST=1
+CMAKE_OUTSOURCE =    true
 
 include ${KOS_PORTS}/scripts/kos-ports.mk


### PR DESCRIPTION
I guess something changed upstream, but in-tree builds are disabled on line 4 of their CMakeLists.txt, meaning we have to do something different on our end.

1) added CMAKE_OUTSOURCE to force an inner "build" dir to be made. 
2) added NOCOPY_TARGET, or else the build would fail trying to copy the
   target unecessarily, since the "cmake install" step already copies.