### PR TITLE
Temp fix for a GCC 15 ICE when compiling raylib4dc with -ffast-math

### DIFF
--- a/raylib4dc/Makefile
+++ b/raylib4dc/Makefile
@@ -22,7 +22,13 @@ KOS_MAKEFILE =      Makefile
 
 PREINSTALL = raylib_preinstall
 
+# Apply patch before build
+PREBUILD =          apply-patch
+
 include ${KOS_PORTS}/scripts/kos-ports.mk
+apply-patch:
+	patch -p1 -d build/${PORTNAME}-${PORTVERSION} < files/raylib4dc-5.5.0.patch
+
 raylib_preinstall:
 	@mkdir -p inst/lib inst/include
 	@cp build/${DISTFILE_DIR}/${TARGET} inst/lib

--- a/raylib4dc/files/raylib4dc-5.5.0.patch
+++ b/raylib4dc/files/raylib4dc-5.5.0.patch
@@ -1,0 +1,14 @@
+diff --git a/src/rmodels.c b/src/rmodels.c
+index 815e6d2..1755bad 100644
+--- a/src/rmodels.c
++++ b/src/rmodels.c
+@@ -3842,6 +3842,9 @@ void DrawBillboardRec(Camera camera, Texture2D texture, Rectangle source, Vector
+     DrawBillboardPro(camera, texture, source, position, up, size, Vector2Scale(size, 0.5), 0.0f, tint);
+ }
+ 
++/* Workaround for GCC 15 ICE in gen_reg_rtc with -ffast-math enabled */
++__attribute__((optimize("-fno-fast-math")))
++
+ // Draw a billboard with additional parameters
+ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector3 up, Vector2 size, Vector2 origin, float rotation, Color tint)
+ {


### PR DESCRIPTION
This file is important for loading models and most likely affects performance. This change is definitely temporary, just to get things working until the ICE is fixed. The error I got follows:

```
during RTL pass: reload
rmodels.c: In function ‘DrawBillboardPro’:
rmodels.c:3919:1: internal compiler error: in gen_reg_rtx, at emit-rtl.cc:1177
 3919 | }
      | ^
0x73a7145c5f74 __libc_start_call_main
        ../sysdeps/nptl/libc_start_call_main.h:58
0x73a7145c6026 __libc_start_main_impl
        ../csu/libc-start.c:360
```

This is the same fix as #131, fixed by applying a patch file to rmodels.c. Thanks to Bruce for linking to that PR and suggesting the same changes.