### PR TITLE
libsmb2: Fix install of headers + switch to master branch

### DIFF
--- a/libsmb2/Makefile
+++ b/libsmb2/Makefile
@@ -14,7 +14,6 @@ NOCOPY_TARGET =     1
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/sahlberg/libsmb2.git
-GIT_BRANCH =        ${PORTNAME}-${PORTVERSION}
 TARGET =            libsmb2.a
 EXAMPLES_DIR =      examples
 

--- a/libsmb2/Makefile
+++ b/libsmb2/Makefile
@@ -19,7 +19,7 @@ TARGET =            libsmb2.a
 EXAMPLES_DIR =      examples
 
 # cmake setup work.
-CMAKE_ARGS =        -DINSTALL_INC_DIR=${KOS_PORTS}/${PORTNAME}/inst/ \
+CMAKE_ARGS =        -DINSTALL_INC_DIR=${KOS_PORTS}/${PORTNAME}/inst/include/ \
                     -DCMAKE_INSTALL_PREFIX=${KOS_PORTS}/${PORTNAME}/inst/
 MAKE_TARGET =       all install
 


### PR DESCRIPTION
The headers were not installed into the correct directory.

libsmb2 6.2 is very old (Dec. 2024), and a lot of things have been improved since then. Notably, the master branch supports KOS' VFS which greatly facilitates its use.