### PR TITLE
libvldmail - Clean up port building.

### DIFF
--- a/libvldmail/Makefile
+++ b/libvldmail/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          libvldmail
-PORTVERSION =       1.0.0
+PORTVERSION =       1.2.1
 
 MAINTAINER =        Donald Haase
 LICENSE =           MIT-0
@@ -9,14 +9,19 @@ SHORT_DESC =        An e-mail address validation library.
 # This port uses CMake.
 PORT_BUILD =        cmake
 CMAKE_OUTSOURCE =   1
+NOCOPY_TARGET = 1
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/dertuxmalwieder/libvldmail.git
+GIT_BRANCH =        master
+GIT_TAG =           release-${PORTVERSION}
+
 TARGET =            libvldmail.a
 INSTALLED_HDRS =    src/vldmail.h
 
-#Passing this causes the test to be built as a .elf in the build dir.
-#It doesn't quite match the current scheme we have for 'examples'
-CMAKE_ARGS =        -DBUILD_THE_TEST=1
+PREINSTALL = vldmail_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
+
+vldmail_preinstall:
+	mkdir -p inst/lib ; cp build/$(PORTNAME)-$(PORTVERSION)/build/$(TARGET) inst/lib; \


### PR DESCRIPTION
A number of changes cleaning up the port:

Add a proper port version based off repo tags to prevent upstream from easily breaking.

Prevent automatic copying of target, as with outsource building it isn't in the expected location.

Remove build_the_test option which no longer exists upstream.

Properly copy the built library to the expected folder. Otherwise cmake was attempting to install it directly from the build dir which would be removed with `make clean`.