### PR TITLE
libpng: Avoid ICE with some GCC versions

### DIFF
--- a/libpng/files/KOSMakefile.mk
+++ b/libpng/files/KOSMakefile.mk
@@ -14,6 +14,9 @@ KOS_CFLAGS += -I. \
 
 defaultall: pnglibconf.h fix-pngh $(OBJS) subdirs linklib
 
+# Avoid ICE with some GCC versions
+pngwrite.o: CFLAGS += -O2
+
 # Force the configuration file to be generated.
 pnglibconf.h: scripts/pnglibconf.h.prebuilt
 	cp $< $@


### PR DESCRIPTION
There is a bug in GCC >= 15 that is triggered by compiling pngwrite.c with -O3. Using -O2 instead works fine.