### PR TITLE
Added EXAMPLES_SYMLINK option for kos-ports.

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -98,6 +98,9 @@ force-install: build-stamp $(PREINSTALL)
 
 	@if [ -n "${EXAMPLES_DIR}" ] ; then \
 		ln -s ${KOS_PORTS}/${PORTNAME}/inst/examples ${KOS_PORTS}/examples/${PORTNAME} ; \
+		if [ -n "${EXAMPLES_SYMLINK}" ] ; then \
+			ln -s ${KOS_PORTS}/${PORTNAME}/inst/examples ${KOS_BASE}/examples/${KOS_ARCH}/${PORTNAME} ; \
+		fi ; \
 	fi
 
 	@echo "Marking ${PORTNAME} ${PORTVERSION} as installed."

--- a/scripts/uninstall.mk
+++ b/scripts/uninstall.mk
@@ -24,6 +24,9 @@ uninstall:
 			rm -f ${KOS_PORTS}/include/${PORTNAME} ; \
 		fi ; \
 		rm -fr inst ; \
+		if [ -n "${EXAMPLES_SYMLINK}" ] ; then \
+			rm -f ${KOS_BASE}/examples/${KOS_ARCH}/${PORTNAME} ; \
+		fi ; \
 		echo "Uninstalled ${PORTNAME}." ; \
 		echo "WARNING: Dependency checking not done, any dependent ports will be broken." ; \
 	else \

--- a/sh4zam/Makefile
+++ b/sh4zam/Makefile
@@ -11,8 +11,9 @@ PORT_BUILD =        cmake
 GIT_REPOSITORY =    https://github.com/gyrovorbis/sh4zam.git
 
 TARGET =            libsh4zam.a
-HDR_DIRECTORY = 	include/sh4zam
+HDR_DIRECTORY =     include/sh4zam
 HDR_INSTDIR =       sh4zam
 EXAMPLES_DIR =      example
+EXAMPLES_SYMLINK =  1
 
 include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/sh4zam/pkg-descr
+++ b/sh4zam/pkg-descr
@@ -1,3 +1,10 @@
-SH4ZAM is a hand-optimized, general-purpose math and linear algebra library for harnessing the floating-point power of the SH4 processor in the Sega Dreamcast. It originally began as a collection of inline assembly routines developed specifically to accelerate the math in the Grand Theft Auto 3 and Vice City DC ports. These routines, along with many others from various contributors, have been separated and combined into a single standalone library, which can be leveraged to bring gainz to the Dreamcast and SuperH communities at large.
+SH4ZAM is a hand-optimized, general-purpose math and linear algebra library for
+harnessing the floating-point power of the SH4 processor in the Sega Dreamcast.
+
+It originally began as a collection of inline assembly routines developed
+specifically to accelerate the math in the Grand Theft Auto 3 and Vice City
+DC ports. These routines, along with many others from various contributors,
+have been separated and combined into a single standalone library, which can
+be leveraged to bring gainz to the Dreamcast and SuperH communities at large.
 
 URL: http://sh4zam.falcogirgis.net


### PR DESCRIPTION
For well-behaved ports which contain ready-to-go Makefile-based examples
that are idiomatic with the rest of the KOS examples, EXAMPLES_SYMLINK
may be set to 1 within the Makefile of a kos-port to add a symlink to
the port's example directory to KOS's example directory, so that it's
more easily discoverable and can be found with the rest of the KOS
examples.