### PR TITLE
Sdl with GLdc

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -14,7 +14,16 @@ GIT_REPOSITORY =    https://github.com/libsdl-org/SDL-1.2.git
 
 KOS_MAKEFILE =      Makefile.dc
 
-TARGET =            libSDL.a
+#set GL = 1 to link with GLdc
+GL ?=               1
+ifeq ($(GL),1)
+  MAKE_TARGET =       GL=1
+  TARGET =            libSDL_gl.a
+else
+  MAKE_TARGET =       GL=
+  TARGET =            libSDL.a
+endif
+
 HDR_DIRECTORY =     include
 HDR_INSTDIR =       SDL
 


### PR DESCRIPTION
Make the default build for SDL-1.2 library to integrate with GLdc library. 
change GL=1 in the Makefile to GL=0 to build without GLdc integration.