### PR TITLE
Add miniaudio port with official KOS back-end.

### DIFF
--- a/miniaudio/Makefile
+++ b/miniaudio/Makefile
@@ -1,0 +1,19 @@
+# Port Metadata
+PORTNAME =          miniaudio
+PORTVERSION =       dev-0.12
+
+MAINTAINER =        mackron
+LICENSE =           Public Domain/MIT No Attribution
+SHORT_DESC =        Audio playback and capture library written in C, in a single source file.
+
+PORT_BUILD =        cmake
+
+GIT_REPOSITORY =    https://github.com/mackron/miniaudio.git
+GIT_BRANCH =        dev-0.12
+
+TARGET =            libminiaudio.a
+MAKE_TARGET =       miniaudio
+INSTALLED_HDRS =    miniaudio.h
+EXAMPLES_DIR =      tests/dreamcast
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/miniaudio/Makefile
+++ b/miniaudio/Makefile
@@ -6,6 +6,8 @@ MAINTAINER =        mackron
 LICENSE =           Public Domain/MIT No Attribution
 SHORT_DESC =        Audio playback and capture library written in C, in a single source file.
 
+REQUIRES_ABI =      -m4-single
+
 PORT_BUILD =        cmake
 
 GIT_REPOSITORY =    https://github.com/mackron/miniaudio.git
@@ -14,6 +16,5 @@ GIT_BRANCH =        dev-0.12
 TARGET =            libminiaudio.a
 MAKE_TARGET =       miniaudio
 INSTALLED_HDRS =    miniaudio.h
-EXAMPLES_DIR =      tests/dreamcast
 
 include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/miniaudio/pkg-descr
+++ b/miniaudio/pkg-descr
@@ -1,0 +1,5 @@
+miniaudio is written in C with no dependencies except the standard library and
+should compile clean on all major compilers without the need to install any
+additional development packages. All major desktop and mobile platforms are supported.
+
+URL: https://miniaud.io/


### PR DESCRIPTION
A few months ago, the author of miniaudio, mackron, added first-party support for a KOS back-end to upstream miniaudio within a dev branch.

This port has already been previewed by many over the following months, including myself as well as users of raylib 6.0.

We have many people who are using this library on the DC already, except they aren't even using the dedicated KOS back-end. The time has come to add it as a first-party kos-port as a sweet-ass multi-format audio back-end.