### PR TITLE
mbedtls: Use multiple targets, update upstream version

### DIFF
--- a/mbedtls/Makefile
+++ b/mbedtls/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          mbedtls
-PORTVERSION =       3.6.5
+PORTVERSION =       3.6.6
 
 MAINTAINER =        Donald Haase
 LICENSE =           Apache 2.0 OR GPL 2.0 or later
@@ -11,7 +11,7 @@ PORT_BUILD =        cmake
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/Mbed-TLS/mbedtls.git
 GIT_BRANCH =        v$(PORTVERSION)
-TARGET =            lib$(PORTNAME).a
+TARGET =            lib$(PORTNAME).a libmbedx509.a libmbedcrypto.a
 
 HDR_DIRECTORY =     include/mbedtls
 
@@ -32,9 +32,6 @@ mbedtls_prebuild:
 # Copy all lib files, link extras, and install psa/ headers (TF-PSA-Crypto submodule)
 mbedtls_preinstall:
 	mkdir -p inst/lib ; cp build/$(PORTNAME)-$(PORTVERSION)/library/*.a inst/lib; \
-    rm -f ${KOS_PORTS}/lib/libmbedx509.a ; rm -f ${KOS_PORTS}/lib/libmbedcrypto.a ; \
-    ln -s ${KOS_PORTS}/${PORTNAME}/inst/lib/libmbedx509.a ${KOS_PORTS}/lib/libmbedx509.a ; \
-    ln -s ${KOS_PORTS}/${PORTNAME}/inst/lib/libmbedcrypto.a ${KOS_PORTS}/lib/libmbedcrypto.a ; \
     mkdir -p inst/include/psa ; \
     cp build/$(PORTNAME)-$(PORTVERSION)/include/psa/*.h inst/include/psa/ ; \
     rm -f ${KOS_PORTS}/include/psa ; \

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -62,7 +62,9 @@ force-install: build-stamp $(PREINSTALL)
 		cd ${DISTFILE_DIR} ; \
 	fi ; \
 	if [ -z "${NOCOPY_TARGET}" ] ; then \
-		cp ${TARGET} ../../inst/lib ; \
+		for target in ${TARGET}; do \
+			cp $$p/$$target ../../inst/lib ; \
+		done ; \
 	fi ; \
 	for _file in ${INSTALLED_HDRS}; do \
 		cp $$_file ../../inst/include ; \
@@ -91,8 +93,10 @@ force-install: build-stamp $(PREINSTALL)
 		ln -s ${KOS_PORTS}/${PORTNAME}/inst/include ${KOS_PORTS}/include/${PORTNAME} ; \
 	fi
 
-	@rm -f ${KOS_PORTS}/lib/${TARGET}
-	@ln -s ${KOS_PORTS}/${PORTNAME}/inst/lib/${TARGET} ${KOS_PORTS}/lib/${TARGET}
+	@for target in $(TARGET); do \
+		rm -f ${KOS_PORTS}/lib/$$target ; \
+		ln -s ${KOS_PORTS}/${PORTNAME}/inst/lib/$$target ${KOS_PORTS}/lib/$$target ; \
+	done
 
 	@rm -f ${KOS_PORTS}/examples/${PORTNAME}
 


### PR DESCRIPTION
Update makefile to take advantage of multiple target lib definition added in #152. Additionally bump the version number to the newest upstream.

With #152 being closed, I took the scripting update from it and brought it here to get it in with the update to the mbedtls version.