### PR TITLE
autotools: Cache `configure` results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib/*
 examples/*
 inst
 .DS_Store
+./config.*

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -13,7 +13,7 @@ ifeq ($(PORT_BUILD), autotools)
 	else \
 		cd build/${DISTFILE_DIR} ; \
 	fi ; \
-	CC=kos-cc ${CONFIGURE_DEFS} ./configure --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
+	CC=kos-cc ${CONFIGURE_DEFS} ./configure --cache-file=${KOS_PORTS}/config.${KOS_GCCVER}.cache --prefix=${KOS_PORTS}/${PORTNAME}/inst --host=${AUTOTOOLS_HOST} ${CONFIGURE_ARGS} ; \
 	$(MAKE) ${MAKE_TARGET} ;
 else ifeq ($(PORT_BUILD), cmake)
 	@if [ -z "${DISTFILE_DIR}" ] ; then \


### PR DESCRIPTION
The results of these shouldn't be changing aside from switching toolchains out, so tried to mitigate that by versioning by gcc version. This substantially speeds up any autotools based port's rebuilds by skipping most/all of the testing being done.

This could probably use some more pieces around it to help prevent issues where we've updated. Perhaps it could be something that is just for the lifetime of a `./build-all.sh`, or get cleaned by the uninstall/clean scripts? Open to suggestions if anyone has any.