### PR TITLE
Update to stdint types.

### DIFF
--- a/libjpeg/files/kos_img.c
+++ b/libjpeg/files/kos_img.c
@@ -8,15 +8,20 @@
 */
 
          
-#include <kos.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 #include "jpeglib.h"
 
+#include <kos/dbglog.h>
+#include <kos/img.h>
+
 /* Load a JPEG into a KOS PIImage */
-int jpeg_to_img(const char *filename, int scale, kos_img_t * rv) {
+int jpeg_to_img(const char *filename, int scale, kos_img_t *rv) {
 	int		i;
-	uint16		* ourbuffer;
-	uint16		* temp_tex;
+	uint16_t		*ourbuffer;
+	uint16_t		*temp_tex;
 
 	/* This struct contains the JPEG decompression parameters and pointers to
 	 * working space (which is allocated as needed by the JPEG library).
@@ -65,10 +70,10 @@ int jpeg_to_img(const char *filename, int scale, kos_img_t * rv) {
 	/* Allocate the output buffers */
 	rv->w = cinfo.image_width;
 	rv->h = cinfo.image_height;
-	rv->data = (void *)( temp_tex = (uint16 *)malloc(rv->w * rv->h * 2) );
+	rv->data = (void *)( temp_tex = (uint16_t *)malloc(rv->w * rv->h * 2) );
 	rv->fmt = KOS_IMG_FMT(KOS_IMG_FMT_RGB565, 0);
 	rv->byte_count = rv->w * rv->h * 2;
-	ourbuffer = (uint16 *)malloc(rv->w * 2);
+	ourbuffer = (uint16_t *)malloc(rv->w * 2);
     
 	/* Step 4: set parameters for decompression */
 	assert( scale == 1 || scale == 2 || scale == 4 || scale == 8 );

--- a/libtremor/files/sndoggvorbis.c
+++ b/libtremor/files/sndoggvorbis.c
@@ -9,22 +9,26 @@
  * ivorbisfile (Tremor).
  */
 
-#include <kos.h>
+#include <string.h>
 /* #include <sndserver.h> */
 #include <assert.h>
 #include "ivorbisfile.h"
 #include "sndvorbisfile.h"
+
+#include <kos/dbglog.h>
+#include <kos/thread.h>
+#include <dc/sound/stream.h>
 
 /* Enable this #define to do timing testing */
 /* #define TIMING_TESTS */
 
 #define BUF_SIZE 65536			/* Size of buffer */
 
-static uint8 pcm_buffer[BUF_SIZE+16384];	/* complete buffer + 16KB safety */
-static uint8 *pcm_ptr=pcm_buffer;		/* place we write to */
+static uint8_t pcm_buffer[BUF_SIZE+16384];	/* complete buffer + 16KB safety */
+static uint8_t *pcm_ptr=pcm_buffer;		/* place we write to */
 
-static int32 pcm_count=0;			/* bytes in buffer */
-static int32 last_read=0;			/* number of bytes the sndstream driver grabbed at last callback */
+static int32_t pcm_count=0;			/* bytes in buffer */
+static int32_t last_read=0;			/* number of bytes the sndstream driver grabbed at last callback */
 
 static int tempcounter =0;
 


### PR DESCRIPTION
Old `<arch/types.h>` types were being used in some of our port patches. While updating them for that, also reduce their includes.

Per https://github.com/KallistiOS/KallistiOS/issues/840