### PR TITLE
Update SDL-1.2 Makefile to build libGL as a dependency

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -6,8 +6,8 @@ MAINTAINER =        Nobody
 LICENSE =           LGPLv2.1
 SHORT_DESC =        Simple Directmedia Library
 
-# No dependencies beyond the base system.
-DEPENDENCIES =
+# Required for OpenGL hardware acceleration
+DEPENDENCIES =      libGL
 
 # What files we need to download, and where from.
 GIT_REPOSITORY =    https://github.com/libsdl-org/SDL-1.2.git


### PR DESCRIPTION
This PR updates the SDL-1.2 port to enforce libGL as a build-time dependency. This is now required to support the updated upstream libSDL Dreamcast port.

gpf@GPF:/opt/toolchains/dc/kos-ports/SDL$ make install clean
SDL is not currently installed.
SDL is compatible with any floating-point ABI.
SDL requires libGL to be installed. Building...
make[1]: Entering directory '/opt/toolchains/dc/kos-ports/libGL'
libGL is not currently installed.
libGL is compatible with any floating-point ABI.
Finished processing dependencies for libGL.
Fetching libGL from https://gitlab.com/simulant/GLdc.git ...
Cloning into 'libGL-1.1.0'...