### PR TITLE
ver_cmp: Correctly handle empty PORTVERSION

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -1,6 +1,5 @@
 # Port Metadata
 PORTNAME =          SDL
-PORTVERSION =       1.2.15
 
 MAINTAINER =        Nobody
 LICENSE =           LGPLv2.1

--- a/scripts/vercmp.sh
+++ b/scripts/vercmp.sh
@@ -8,7 +8,13 @@
 # the bottom to return back to the calling shell
 # Returns 0 if the version numbers are identical, 1 if the first is greater than
 # the second, 2 if the second is greater than the first.
+
+# An additional change checks if no version is set at all, in which case it's considered higher.
 vercomp () {
+    if [ "$2" = '' ];
+    then
+        return 2
+    fi
     if [[ $1 == $2 ]]
     then
         return 0


### PR DESCRIPTION
This will allow a port that is meant to simply track a dynamic git branch (or other download source) to always rebuild when checking if it's out of date. Currently we assign an arbitrary version number, but unless that version number changes or the port is explicitly uninstalled, it will never get rebuilt on build-all which undermined the purpose of the version check.

The rest of the build system already works fine if PORTVERSION is empty. Allows #153 's update to work as intended, always checking an untagged master branch on attempted install.