### PR TITLE
libtremor: Fix building on v2.2.x

### DIFF
--- a/libtremor/files/sndoggvorbis.c
+++ b/libtremor/files/sndoggvorbis.c
@@ -16,6 +16,7 @@
 #include "sndvorbisfile.h"
 
 #include <kos/dbglog.h>
+#include <kos/sem.h>
 #include <kos/thread.h>
 #include <dc/sound/stream.h>
 


### PR DESCRIPTION
Some of the include chains have changed since v2.2.x and the previous update #159 that removed `<kos.h>` made `<kos/sem.h>` inaccessible to libtremor.