### PR TITLE
Add lftpd port.

### DIFF
--- a/lftpd/Makefile
+++ b/lftpd/Makefile
@@ -1,0 +1,21 @@
+# Port Metadata
+PORTNAME =          lftpd
+PORTVERSION =       1.0.0
+
+MAINTAINER =        Andy Barajas
+LICENSE =           MIT
+SHORT_DESC =        Small embeddable FTP server library
+
+DEPENDENCIES =
+
+# Upstream source.
+GIT_REPOSITORIES =  https://github.com/Dreamcast-Projects/lftpd.git
+
+TARGET =            liblftpd.a
+INSTALLED_HDRS =    include/lftpd.h
+HDR_INSTDIR =       lftpd
+
+# KOS build file copied into the fetched source tree.
+KOS_DISTFILES =     KOSMakefile.mk
+
+include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/lftpd/files/KOSMakefile.mk
+++ b/lftpd/files/KOSMakefile.mk
@@ -1,0 +1,5 @@
+TARGET = liblftpd.a
+OBJS = lftpd.o lftpd_inet.o lftpd_io.o lftpd_log.o lftpd_string.o
+KOS_CFLAGS += -Iinclude -I.
+
+include ${KOS_PORTS}/scripts/lib.mk

--- a/lftpd/pkg-descr
+++ b/lftpd/pkg-descr
@@ -1,0 +1,6 @@
+lftpd is a small, embeddable FTP server library implementing a usable subset of
+RFC 959 (with passive mode). It is designed to be dropped into an application to
+serve files over a standard FTP client.
+
+Originally written by Jason von Nieda and distributed under the MIT license.
+Upstream: https://github.com/vonnieda/lftpd


### PR DESCRIPTION
lftpd is a small, embeddable FTP server library implementing a usable subset of FTP protocol. Ported to DC and enhanced by @Bruceleeto, @pcercuei and myself