### PR TITLE
Correct installation of non-cmake libs and libGL/libcmark

### DIFF
--- a/libGL/Makefile
+++ b/libGL/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          libGL
-PORTVERSION =       1.1.0
+PORTVERSION =       1.1.1
 
 MAINTAINER =        Luke Benstead <kazade@gmail.com>
 LICENSE =           2-clause BSD (see LICENSE in the source distribution)
@@ -10,7 +10,7 @@ PORT_BUILD =        cmake
 
 GIT_REPOSITORY =    https://gitlab.com/simulant/GLdc.git
 
-TARGET =            libGL.a
+TARGET =            libGL.a libGLU.a
 INSTALLED_HDRS =    include/GL/gl.h include/GL/glext.h include/GL/glkos.h include/GL/glu.h
 HDR_COMDIR =        GL
 EXAMPLES_DIR =      samples

--- a/libcmark/Makefile
+++ b/libcmark/Makefile
@@ -1,6 +1,6 @@
 # Port Metadata
 PORTNAME =          libcmark
-PORTVERSION =       0.31.0
+PORTVERSION =       0.31.2
 
 MAINTAINER =        Donald Haase
 LICENSE =           Custom (see the file COPYING provided with headers or at https://github.com/commonmark/cmark/blob/master/COPYING)
@@ -28,4 +28,4 @@ PREINSTALL =        cmark_preinstall
 
 include ${KOS_PORTS}/scripts/kos-ports.mk
 cmark_preinstall:
-	cp build/${PORTNAME}-${PORTVERSION}/build/src/${TARGET} build/${PORTNAME}-${PORTVERSION}
+	cp build/${PORTNAME}-${PORTVERSION}/build/src/${TARGET} build/${TARGET}

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -61,6 +61,11 @@ force-install: build-stamp $(PREINSTALL)
 	else \
 		cd ${DISTFILE_DIR} ; \
 	fi ; \
+	if [ -z "${CMAKE_OUTSOURCE}" ] ; then \
+		p=. ; \
+	else \
+		p=.. ; \
+	fi ; \
 	if [ -z "${NOCOPY_TARGET}" ] ; then \
 		for target in ${TARGET}; do \
 			cp $$p/$$target ../../inst/lib ; \


### PR DESCRIPTION
The multilib expansion unconditionally was testing for 'p' to test for the lib being in '.' vs '..' for cmake outsource builds, but that p was not being set outside of cmake builds.

There should be a cleaner way to have p just default to '.' and have the cmake outsource override it, but this works.

Additionally libGL needed updating after upstream changes now require building two libraries.
Finally, libcmark also needed the preinstall script to be updated as it was now placing the lib in a different folder than where the scripts were looking.