### PR TITLE
Modplug update

### DIFF
--- a/libmodplug/Makefile
+++ b/libmodplug/Makefile
@@ -1,23 +1,20 @@
 # Port Metadata
 PORTNAME =          libmodplug
-PORTVERSION =       0.7
+PORTVERSION =       0.8.9
 
 MAINTAINER =        Nobody
 LICENSE =           Public Domain
 SHORT_DESC =        A library for MOD-like tracker music formats
 
-# No dependencies beyond the base system.
-DEPENDENCIES =
+PORT_BUILD = cmake
 
 # What files we need to download, and where from.
-GIT_REPOSITORIES =  git://git.code.sf.net/p/cadcdev/libmodplug \
-                    https://github.com/KallistiOS/libmodplug.git
+GIT_REPOSITORIES =  https://git.code.sf.net/p/modplug-xmms/git
 
 TARGET =            libmodplug.a
-INSTALLED_HDRS =    include/modplug.h include/sndfile.h include/stdafx.h
+INSTALLED_HDRS =    src/modplug.h src/libmodplug/sndfile.h src/libmodplug/stdafx.h
 HDR_INSTDIR =       modplug
 
-# KOS Distributed extras (to be copied into the build tree)
-KOS_DISTFILES =     KOSMakefile.mk
+DISTFILE_DIR = ${PORTNAME}-${PORTVERSION}/libmodplug
 
 include ${KOS_PORTS}/scripts/kos-ports.mk

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -68,17 +68,17 @@ force-install: build-stamp $(PREINSTALL)
 	fi ; \
 	if [ -z "${NOCOPY_TARGET}" ] ; then \
 		for target in ${TARGET}; do \
-			cp $$p/$$target ../../inst/lib ; \
+			cp $$p/$$target ${KOS_PORTS}/${PORTNAME}/inst/lib ; \
 		done ; \
 	fi ; \
 	for _file in ${INSTALLED_HDRS}; do \
-		cp $$_file ../../inst/include ; \
+		cp $$_file ${KOS_PORTS}/${PORTNAME}/inst/include ; \
 	done ; \
 	if [ -n "${HDR_DIRECTORY}" ] ; then \
-		cp -R ${HDR_DIRECTORY}/. ../../inst/include ; \
+		cp -R ${HDR_DIRECTORY}/. ${KOS_PORTS}/${PORTNAME}/inst/include ; \
 	fi ; \
 	if [ -n "${EXAMPLES_DIR}" ] ; then \
-		cp -R ${EXAMPLES_DIR}/. ../../inst/examples ; \
+		cp -R ${EXAMPLES_DIR}/. ${KOS_PORTS}/${PORTNAME}/inst/examples ; \
 	fi
 
 	@if [ -n "${HDR_COMDIR}" ] ; then \


### PR DESCRIPTION
First a fix to the build script for the installation process. Trying to specify a subfolder of the git repo to build from tripped over this bug.

Then migrate the libmodplug port to pull from the official repo. Our hosted one had no specialized KOS code in it, it was just whatever version was pulled down 20 years ago and we never got around to dumping it.

modplug example builds, but needs some testing to be sure there aren't any updates needed for expected function.

EDIT: example also works just fine with this mainline modplug. Updated it so it cleans up after itself better.