### PR TITLE
fix(build): address FreeType, Vorbis, and bulk-build failures

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,6 +1,6 @@
 # Select how to download files inside the kos-ports tree. Examples are given for
 # cURL and wget.
-FETCH_CMD = curl --progress-bar -O -L
+FETCH_CMD = curl --fail --progress-bar -O -L
 #FETCH_CMD = wget --progress=bar
 
 # Set the command that will be used for extracting archive files. Currently this

--- a/freetype/Makefile
+++ b/freetype/Makefile
@@ -16,8 +16,8 @@ NOCOPY_TARGET =     1
 DEPENDENCIES =      libbz2 zlib libpng
 
 # What files we need to download, and where from.
-DOWNLOAD_SITES =    https://download.savannah.gnu.org/releases/freetype/ \
-                    https://sourceforge.net/projects/freetype/files/freetype2/2.13.3/
+DOWNLOAD_SITES =    https://sourceforge.net/projects/freetype/files/freetype2/2.13.3 \
+                    https://download.savannah.gnu.org/releases/freetype
 DOWNLOAD_FILES =    freetype-2.13.3.tar.gz
 
 TARGET =            libfreetype.a

--- a/liboggvorbisplay/Makefile
+++ b/liboggvorbisplay/Makefile
@@ -19,4 +19,9 @@ HDR_INSTDIR =       oggvorbis
 # KOS Distributed extras (to be copied into the build tree)
 KOS_DISTFILES =     KOSMakefile.mk
 
+PREBUILD =          liboggvorbisplay_prebuild
+
 include ${KOS_PORTS}/scripts/kos-ports.mk
+
+liboggvorbisplay_prebuild:
+	patch -p1 -d build/${PORTNAME}-${PORTVERSION} < files/${PORTNAME}-${PORTVERSION}.patch

--- a/liboggvorbisplay/files/KOSMakefile.mk
+++ b/liboggvorbisplay/files/KOSMakefile.mk
@@ -1,5 +1,6 @@
 TARGET = liboggvorbisplay.a
 OBJS = liboggvorbisplay/main.o liboggvorbisplay/sndoggvorbis.o
-KOS_CFLAGS += -Iinclude -Iliboggvorbisplay
+# Use installed Ogg headers instead of the legacy copies in include/ogg.
+KOS_CFLAGS += -iquote include -Iliboggvorbisplay
 
 include ${KOS_PORTS}/scripts/lib.mk

--- a/liboggvorbisplay/files/liboggvorbisplay-2.0.0.patch
+++ b/liboggvorbisplay/files/liboggvorbisplay-2.0.0.patch
@@ -1,0 +1,19 @@
+--- a/liboggvorbisplay/sndoggvorbis.c
++++ b/liboggvorbisplay/sndoggvorbis.c
+@@ -12 +12,2 @@
+ #include <kos.h>
++#include <stdint.h>
+@@ -23,5 +24,5 @@
+-static uint8 pcm_buffer[BUF_SIZE + 16384] __attribute__((aligned(32)));
+-static uint8 *pcm_ptr=pcm_buffer;		/* place we write to */
+-
+-static int32 pcm_count=0;			/* bytes in buffer */
+-static int32 last_read=0;			/* number of bytes the sndstream driver grabbed at last callback */
++static char pcm_buffer[BUF_SIZE + 16384] __attribute__((aligned(32)));
++static char *pcm_ptr=pcm_buffer;		/* place we write to */
++
++static int32_t pcm_count=0;			/* bytes in buffer */
++static int32_t last_read=0;			/* number of bytes the sndstream driver grabbed at last callback */
+@@ -204 +205 @@
+-	uint32 s_s, s_ms, e_s, e_ms;
++	uint32_t s_s, s_ms, e_s, e_ms;

--- a/libtremor/Makefile
+++ b/libtremor/Makefile
@@ -15,7 +15,7 @@ GIT_BRANCH =        lowmem
 
 TARGET =            libtremor.a
 INSTALLED_HDRS =    ivorbiscodec.h ivorbisfile.h sndoggvorbis.h
-HDR_INSTDIR =       vorbis
+HDR_COMDIR =        vorbis
 
 # KOS Distributed extras (to be copied into the build tree)
 KOS_DISTFILES =     KOSMakefile.mk sndoggvorbis.h sndoggvorbis.c main.c \

--- a/libvorbis/Makefile
+++ b/libvorbis/Makefile
@@ -15,7 +15,7 @@ DOWNLOAD_FILES =    ${PORTNAME}-${PORTVERSION}.tar.gz
 TARGET =            libvorbis.a
 INSTALLED_HDRS =    include/vorbis/codec.h include/vorbis/vorbisenc.h \
                     include/vorbis/vorbisfile.h
-HDR_INSTDIR =       vorbis
+HDR_COMDIR =        vorbis
 
 # KOS Distributed extras (to be copied into the build tree)
 KOS_DISTFILES =     KOSMakefile.mk

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -81,7 +81,17 @@ force-install: build-stamp $(PREINSTALL)
 		cp -R ${EXAMPLES_DIR}/. ../../inst/examples ; \
 	fi
 
+# Preserve existing headers when migrating from a directory symlink.
 	@if [ -n "${HDR_COMDIR}" ] ; then \
+		if [ -L "${KOS_PORTS}/include/${HDR_COMDIR}" ] ; then \
+			_old_hdrdir=$$(cd "${KOS_PORTS}/include/${HDR_COMDIR}" && pwd -P) || exit 1 ; \
+			rm -f "${KOS_PORTS}/include/${HDR_COMDIR}" || exit 1 ; \
+			mkdir -p "${KOS_PORTS}/include/${HDR_COMDIR}" || exit 1 ; \
+			for _file in "$$_old_hdrdir"/*; do \
+				[ -e "$$_file" ] || continue ; \
+				ln -s "$$_file" "${KOS_PORTS}/include/${HDR_COMDIR}" || exit 1 ; \
+			done ; \
+		fi ; \
 		mkdir -p ${KOS_PORTS}/include/${HDR_COMDIR} ; \
 		for _file in ${KOS_PORTS}/${PORTNAME}/inst/include/*; do \
 			rm -f ${KOS_PORTS}/include/${HDR_COMDIR}/`basename $$_file` ; \

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -13,6 +13,11 @@ error_count=0
 for _dir in ${KOS_PORTS}/* ; do
     if [ -d "${_dir}" ] ; then
         if [ -f "${_dir}/Makefile" ] ; then
+            if [ "${_dir##*/}" = "libKGL" ] ; then
+                echo "Skipping libKGL in build-all."
+                continue
+            fi
+
             echo "Checking if ${_dir} is installed and up-to-date..."
             ${KOS_MAKE} -C "${_dir}" version-check > /dev/null 2>&1
             rv=$?

--- a/utils/build-all.sh
+++ b/utils/build-all.sh
@@ -6,11 +6,16 @@
 # Copyright (C) 2024 Andy Barajas
 #
 
-cd ${KOS_PORTS}
+if [ -z "${KOS_PORTS}" ] || [ -z "${KOS_MAKE}" ] ; then
+    echo "KOS_PORTS and KOS_MAKE must be set. Source your KOS environ.sh before running this script." >&2
+    exit 1
+fi
+
+cd "${KOS_PORTS}" || exit 1
 errors=""
 error_count=0
 
-for _dir in ${KOS_PORTS}/* ; do
+for _dir in "${KOS_PORTS}"/* ; do
     if [ -d "${_dir}" ] ; then
         if [ -f "${_dir}/Makefile" ] ; then
             if [ "${_dir##*/}" = "libKGL" ] ; then


### PR DESCRIPTION
## Summary

Address several failures encountered when building kos-ports:
invalid FreeType downloads, conflicting Vorbis headers, outdated
liboggvorbisplay code, and legacy libKGL build failures.

Also prevent build-all.sh from silently succeeding when the KOS
environment has not been loaded.

## Changes

### FreeType downloads

- Prefer SourceForge, with Savannah retained as fallback.
- Remove trailing slashes from download sites to avoid doubled separators.
- Add --fail to the default curl command so HTTP errors trigger the
  next configured download source instead of being accepted as downloads.

### Vorbis headers and playback

libvorbis and libtremor both replaced the include/vorbis directory
symlink. Installing either could hide the other's headers, while
dependency checks still considered both installed.

- Use HDR_COMDIR for both ports so their headers coexist.
- Convert existing directory symlinks into shared directories during
  installation, preserving the previously exposed headers.
- Use -iquote for liboggvorbisplay's local headers so its bundled,
  outdated Ogg headers do not override the installed libogg headers.
- Apply a source patch replacing obsolete KOS integer typedefs with
  standard C types and using char buffers to match the ov_read API.

### Bulk-build behavior

- Skip legacy libKGL with an explicit message, avoiding its known build
  failure during bulk builds. The port remains available manually.
- Require KOS_PORTS and KOS_MAKE, with instructions to source environ.sh
  when either is missing.
- Quote the ports directory and stop if changing directory fails.

## Validation

- Downloaded FreeType from SourceForge and verified its expected
  4,063,324-byte size and existing SHA-256 checksum.
- Reproduced the original Vorbis missing-header failure.
- Verified both Vorbis/Tremor installation orders, reinstallation,
  uninstall behavior, and migration from either legacy directory symlink.
- Cross-compiled liboggvorbisplay and linked a Dreamcast smoke-test
  executable.
- Used simulated builds to verify environment errors, directory handling,
  libKGL skipping, normal port processing, and failure reporting.
- Shell syntax and branch-wide git diff --check passed.

Validation was targeted; a complete bulk build and playback on Dreamcast
hardware were not performed.

## Existing installations

Previously cached invalid FreeType archives must be cleared before
retrying. Affected Vorbis installations require reinstallation to apply
the shared-header layout; installation markers alone do not repair it.